### PR TITLE
Repetition_fix - Allowed repetition in dataset references

### DIFF
--- a/Star2xml/configuration_files/xml_schema.yaml
+++ b/Star2xml/configuration_files/xml_schema.yaml
@@ -794,10 +794,12 @@ dataset:
       *tx: "Dataset_type"
 
     RUN_REF:  # OPT
+      *RN:
       *att:
         refname: "RUN.Alias"
 
     ANALYSIS_REF: # OPT
+      *RN:
       *att:
         refname: "ANALYSIS.Alias"
 


### PR DESCRIPTION
A user found repeated references in datasets not being processed correctly. Solved it by adding '*RN:' to the corresponding nodes.