### PR TITLE
Order_fix - Fixed the order of nodes in SEQUENCE_ASSEMBLY

### DIFF
--- a/Star2xml/configuration_files/xml_schema.yaml
+++ b/Star2xml/configuration_files/xml_schema.yaml
@@ -476,18 +476,18 @@ analysis:
               *tx: "SEQUENCE_ASSEMBLY.Name"
             TYPE: # Controlled Vocabulary
               *tx: "SEQUENCE_ASSEMBLY.Type"
+            PARTIAL:
+              *tx: "SEQUENCE_ASSEMBLY.Partial"
             COVERAGE:
               *tx: "SEQUENCE_ASSEMBLY.Coverage"
+            PROGRAM:
+              *tx: "SEQUENCE_ASSEMBLY.Program"
             PLATFORM:
               *tx: "SEQUENCE_ASSEMBLY.Platform"
             MIN_GAP_LENGTH:
               *tx: "SEQUENCE_ASSEMBLY.MinGapLen"
             MOL_TYPE: # Controlled Vocabulary
-              *tx: "SEQUENCE_ASSEMBLY.MoleculeType"
-            PROGRAM:
-              *tx: "SEQUENCE_ASSEMBLY.Program"
-            PARTIAL:
-              *tx: "SEQUENCE_ASSEMBLY.Partial"
+              *tx: "SEQUENCE_ASSEMBLY.MoleculeType"                        
             #! Check if it's worth it to use:
             # TPA:
             #   *tx: "Sequence_Assembly.TPA"


### PR DESCRIPTION
Fixed the order of a few nodes within the configuration files so that the output XMLs have the correct order and validation is passed. 