### PR TITLE
EE-2260 - Added 'other' and 'unknown'

### DIFF
--- a/schemas/EGA.ArrayAssay.json
+++ b/schemas/EGA.ArrayAssay.json
@@ -52,9 +52,7 @@
         "type": "string",
         "title": "Centername that performed the ArrayAssay",
         "description": "The name of the center (e.g. 'EBI-TEST') responsible for the profiling by microarray (executed the ArrayAssay), if applicable (in case it’s different from the center submitting metadata).",
-        "examples": [
-          "EBI-TEST"
-        ]
+        "examples": [ "EBI-TEST" ]
       },
 
       "array_assay_date": {
@@ -68,9 +66,7 @@
         "type": "integer",
         "title": "Number of samples of the ArrayAssay",
         "description": "Number of samples included in the Assay (i.e. pooled into one single microarray, labelled differently). One sample corresponds to one biological replicate [EFO:0002091] (e.g. genetic content from a single cell, a tissue, buccal swab, etc.) from a single individual or from several individuals. Shall not be mistaken for technical replicates [EFO:0002090] being used several times (see https://www.ebi.ac.uk/seqdb/confluence/pages/viewpage.action?spaceKey=EGA&title=Sample+Representation).",
-        "examples": [
-          30
-        ]
+        "examples": [ 30 ]
       },
 
       "sample_labels": {

--- a/schemas/EGA.ArrayExperiment.json
+++ b/schemas/EGA.ArrayExperiment.json
@@ -59,18 +59,41 @@
             "type": "string",
             "title": "Microarray technology of the ArrayExperiment - ID",
             "description": "The human readable ID (e.g. Two-colour microarray), chosen from a list of CVs, of the microarray technology used at the ArrayExperiment.",
-            "enum": ["One-colour microarray", "Two-colour microarray", "Methylation microarray", "Protein microarray", "Metabolomic microarray", "Single Nucleotide Polymorphism Array", "Tissue Microarray"],
-            "meta:enum": ["One-colour microarray__EFO:0010939", "Two-colour microarray__NCIT:C116153", "Methylation microarray__NCIT:C165222", "Protein microarray__EFO:0002702", "Metabolomic microarray__", "Single Nucleotide Polymorphism Array__NCIT:C116151", "Tissue Microarray__NCIT:C19922"],
+            "enum": ["One-colour microarray", "Two-colour microarray", "Methylation microarray", "Protein microarray", "Metabolomic microarray", "Single Nucleotide Polymorphism Array", "Tissue Microarray", "other", "unknown"],
+            "meta:enum": ["One-colour microarray__EFO:0010939", "Two-colour microarray__NCIT:C116153", "Methylation microarray__NCIT:C165222", "Protein microarray__EFO:0002702", "Metabolomic microarray__", "Single Nucleotide Polymorphism Array__NCIT:C116151", "Tissue Microarray__NCIT:C19922", "The ID of the technology is not listed in the controlled vocabulary, and thus you may choose 'other' and propose a new term using the field 'technology_label'", "The ID of the technology is unknown. If possible, provide context of why using the field 'technology_label'"],
             "examples": [ "One-colour microarray" ]
           },
           "technology_curie": {
             "type": "string",
             "title": "Microarray technology of the ArrayExperiment - CURIE",
             "description": "The CURIE (i.e. ontologized term - e.g. NCIT:C116153), chosen from a list of CVs, of the microarray technology used at the ArrayExperiment.",
-            "enum": ["EFO:0010939", "NCIT:C116153", "NCIT:C165222", "EFO:0002702", "Metabolomic microarray", "NCIT:C116151", "NCIT:C19922"],
+            "enum": ["EFO:0010939", "NCIT:C116153", "NCIT:C165222", "EFO:0002702", "NCIT:C116151", "NCIT:C19922"],
             "examples": [ "EFO:0010939" ]
+          },
+          "technology_label": {
+            "type": "string",
+            "title": "Microarray technology of the ArrayExperiment - Label",
+            "description": "A free-form label (e.g. 'new unlisted technology XYZ...') to add any extra information to the microarray technology used at the ArrayExperiment. Specially useful when the technology_id is 'other', providing the proposed new technology term, or 'unknown', explaining the reasoning behind it.",
+            "examples": [ "new unlisted technology XYZ..." ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "title": "If the technology_id is 'other'",
+              "required": ["technology_id"],
+              "properties": {
+                "technology_id": {
+                  "enum": ["other"]
+                }
+              }
+            },
+            "then": {
+              "title": "Then the technology_label has to be present",
+              "required": ["technology_label"]
+            }
+          }
+        ]
       },
 
       "array_label": {
@@ -95,8 +118,8 @@
             "type": "string",
             "title": "Experimental design of the ArrayExperiment - ID",
             "description": "The human readable ID (e.g. RNA stability design), chosen from a list of CVs, of the experimental design defining the ArrayExperiment.",
-            "enum": ["RNA stability design", "binding site identification design", "case control design", "cell component comparison design", "cell cycle design", "cell type comparison design", "cellular modification design", "clinical history design", "compound treatment design", "cross sectional design", "development or differentiation design", "disease state design", "dose response design", "twin design", "genetic modification design", "genotype design", "growth condition design", "imprinting design", "injury design", "innate behavior design", "organism part comparison design", "organism status design", "pathogenicity design", "population based design", "sex design", "species design", "stimulus or stress design", "strain or line design", "time series design"],
-            "meta:enum": ["RNA stability design__EFO:0001783", "binding site identification design__EFO:0004664", "case control design__EFO:0001427", "cell component comparison design__EFO:0001743", "cell cycle design__EFO:0001744", "cell type comparison design__EFO:0001745", "cellular modification design__EFO:0004666", "clinical history design__EFO:0001780", "compound treatment design__EFO:0001755", "cross sectional design__EFO:0001428", "development or differentiation design__EFO:0001746", "disease state design__EFO:0001756", "dose response design__EFO:0001757", "twin design__EFO:0001431", "genetic modification design__EFO:0001758", "genotype design__EFO:0001748", "growth condition design__EFO:0001759", "imprinting design__EFO:0001747", "injury design__EFO:0001760", "innate behavior design__EFO:0001749", "organism part comparison design__EFO:0001750", "organism status design__EFO:0001751", "pathogenicity design__EFO:0001761", "population based design__EFO:0001430", "sex design__EFO:0001752", "species design__EFO:0001753", "stimulus or stress design__EFO:0001762", "strain or line design__EFO:0001754", "time series design__EFO:0001779"],
+            "enum": ["RNA stability design", "binding site identification design", "case control design", "cell component comparison design", "cell cycle design", "cell type comparison design", "cellular modification design", "clinical history design", "compound treatment design", "cross sectional design", "development or differentiation design", "disease state design", "dose response design", "twin design", "genetic modification design", "genotype design", "growth condition design", "imprinting design", "injury design", "innate behavior design", "organism part comparison design", "organism status design", "pathogenicity design", "population based design", "sex design", "species design", "stimulus or stress design", "strain or line design", "time series design", "other", "unknown"],
+            "meta:enum": ["RNA stability design__EFO:0001783", "binding site identification design__EFO:0004664", "case control design__EFO:0001427", "cell component comparison design__EFO:0001743", "cell cycle design__EFO:0001744", "cell type comparison design__EFO:0001745", "cellular modification design__EFO:0004666", "clinical history design__EFO:0001780", "compound treatment design__EFO:0001755", "cross sectional design__EFO:0001428", "development or differentiation design__EFO:0001746", "disease state design__EFO:0001756", "dose response design__EFO:0001757", "twin design__EFO:0001431", "genetic modification design__EFO:0001758", "genotype design__EFO:0001748", "growth condition design__EFO:0001759", "imprinting design__EFO:0001747", "injury design__EFO:0001760", "innate behavior design__EFO:0001749", "organism part comparison design__EFO:0001750", "organism status design__EFO:0001751", "pathogenicity design__EFO:0001761", "population based design__EFO:0001430", "sex design__EFO:0001752", "species design__EFO:0001753", "stimulus or stress design__EFO:0001762", "strain or line design__EFO:0001754", "time series design__EFO:0001779", "The ID of the experimental design is not listed in the controlled vocabulary, and thus you may choose 'other' and propose a new term using the field 'experimental_design_label'", "The ID of the experimental design is unknown. If possible, provide context of why using the field 'experimental_design_label'"],
             "examples": [ "RNA stability design" ]
           },
           "experimental_design_curie": {
@@ -105,8 +128,31 @@
             "description": "The CURIE (i.e. ontologized term - e.g. EFO:0001783), chosen from a list of CVs, of the experimental design defining the ArrayExperiment",
             "enum": ["EFO:0001783", "EFO:0004664", "EFO:0001427", "EFO:0001743", "EFO:0001744", "EFO:0001745", "EFO:0004666", "EFO:0001780", "EFO:0001755", "EFO:0001428", "EFO:0001746", "EFO:0001756", "EFO:0001757", "EFO:0001431", "EFO:0001758", "EFO:0001748", "EFO:0001759", "EFO:0001747", "EFO:0001760", "EFO:0001749", "EFO:0001750", "EFO:0001751", "EFO:0001761", "EFO:0001430", "EFO:0001752", "EFO:0001753", "EFO:0001762", "EFO:0001754", "EFO:0001779"],
             "examples": [ "EFO:0001783" ]
+          },
+          "experimental_design_label": {
+            "type": "string",
+            "title": "Experimental design of the ArrayExperiment - Label",
+            "description": "A free-form label (e.g. 'new unlisted experimental design XYZ...') to add any extra information to the experimental design of the ArrayExperiment. Specially useful when the experimental_design_id is 'other', providing the proposed new experimental design term, or 'unknown', explaining the reasoning behind it.",
+            "examples": [ "new unlisted experimental design XYZ..." ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "title": "If the experimental_design_id is 'other'",
+              "required": ["experimental_design_id"],
+              "properties": {
+                "experimental_design_id": {
+                  "enum": ["other"]
+                }
+              }
+            },
+            "then": {
+              "title": "Then the experimental_design_label has to be present",
+              "required": ["experimental_design_label"]
+            }
+          }
+        ]
       },
 
       "array_type": {
@@ -120,8 +166,8 @@
             "type": "string",
             "title": "Array type of the ArrayExperiment - ID",
             "description": "The human readable ID (e.g. Proteomic profiling by array), chosen from a list of CVs, of the array type used at the ArrayExperiment.",
-            "enum": ["3C", "4C", "ChIP-chip by array", "ChIP-chip by SNP array", "ChIP-chip by tiling array", "RNAi profiling by array", "Comparative genomic hybridization by array", "Genotyping by array", "Methylation profiling by array", "microRNA profiling by RT-PCR", "microRNA profiling by array", "Proteomic profiling by array", "RIP-chip (RNP immunoprecipitation-chip) by array", "Tiling path by array", "Transcription profiling by array", "Transcription profiling by tiling array", "Translation profiling"],
-            "meta:enum": ["3C__EFO:0007689", "4C__EFO:0007690", "ChIP-chip by array__EFO:0002760", "ChIP-chip by SNP array__EFO:0002764", "ChIP-chip by tiling array__EFO:0002762", "RNAi profiling by array__EFO:0001030", "Comparative genomic hybridization by array__EFO:0000749", "Genotyping by array__EFO:0002767", "Methylation profiling by array__EFO:0002759", "microRNA profiling by RT-PCR__EFO:0007687", "microRNA profiling by array__EFO:0000753", "Proteomic profiling by array__EFO:0002765", "RIP-chip (RNP immunoprecipitation-chip) by array__EFO:0005517", "Tiling path by array__EFO:0001031", "Transcription profiling by array__EFO:0002768", "Transcription profiling by tiling array__EFO:0002769", "Translation profiling__EFO:0001033"], 
+            "enum": ["3C", "4C", "ChIP-chip by array", "ChIP-chip by SNP array", "ChIP-chip by tiling array", "RNAi profiling by array", "Comparative genomic hybridization by array", "Genotyping by array", "Methylation profiling by array", "microRNA profiling by RT-PCR", "microRNA profiling by array", "Proteomic profiling by array", "RIP-chip (RNP immunoprecipitation-chip) by array", "Tiling path by array", "Transcription profiling by array", "Transcription profiling by tiling array", "Translation profiling", "other", "unknown"],
+            "meta:enum": ["3C__EFO:0007689", "4C__EFO:0007690", "ChIP-chip by array__EFO:0002760", "ChIP-chip by SNP array__EFO:0002764", "ChIP-chip by tiling array__EFO:0002762", "RNAi profiling by array__EFO:0001030", "Comparative genomic hybridization by array__EFO:0000749", "Genotyping by array__EFO:0002767", "Methylation profiling by array__EFO:0002759", "microRNA profiling by RT-PCR__EFO:0007687", "microRNA profiling by array__EFO:0000753", "Proteomic profiling by array__EFO:0002765", "RIP-chip (RNP immunoprecipitation-chip) by array__EFO:0005517", "Tiling path by array__EFO:0001031", "Transcription profiling by array__EFO:0002768", "Transcription profiling by tiling array__EFO:0002769", "Translation profiling__EFO:0001033", "The ID of the array type is not listed in the controlled vocabulary, and thus you may choose 'other' and propose a new term using the field 'array_type_label'", "The ID of the array type is unknown. If possible, provide context of why using the field 'array_type_label'"], 
             "examples": [ "ChIP-chip by SNP array" ]
           },
           "array_type_curie": {
@@ -130,8 +176,31 @@
             "description": "The CURIE (i.e. ontologized term - e.g. EFO:0002765), chosen from a list of CVs, of the array type used at the ArrayExperiment.",
             "enum": ["EFO:0007689", "EFO:0007690", "EFO:0002760", "EFO:0002764", "EFO:0002762", "EFO:0001030", "EFO:0000749", "EFO:0002767", "EFO:0002759", "EFO:0007687", "EFO:0000753", "EFO:0002765", "EFO:0005517", "EFO:0001031", "EFO:0002768", "EFO:0002769", "EFO:0001033"],
             "examples": [ "EFO:0007689" ]
+          },
+          "array_type_label": {
+            "type": "string",
+            "title": "Array type of the ArrayExperiment - Label",
+            "description": "A free-form label (e.g. 'new unlisted array type XYZ...') to add any extra information to the array type of the ArrayExperiment. Specially useful when the array_type_id is 'other', providing the proposed new array type term, or 'unknown', explaining the reasoning behind it.",
+            "examples": [ "new unlisted array type XYZ..." ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "title": "If the array_type_id is 'other'",
+              "required": ["array_type_id"],
+              "properties": {
+                "array_type_id": {
+                  "enum": ["other"]
+                }
+              }
+            },
+            "then": {
+              "title": "Then the array_type_label has to be present",
+              "required": ["array_type_label"]
+            }
+          }
+        ]
       },
 
       "assayed_molecule": {
@@ -143,20 +212,43 @@
         "properties": {
           "assayed_molecule_id": {
             "type": "string",
-            "title": "Array type of the ArrayExperiment - ID",
+            "title": "Assayed molecule of the ArrayExperiment - ID",
             "description": "The human readable ID (e.g. DNA assay), chosen from a list of CVs, of the assayed molecule.",
-            "enum": ["DNA assay", "RNA assay", "Metabolomic profiling", "Protein assay"],
-            "meta:enum": ["DNA assay__EFO:0001456", "RNA assay__EFO:0001457", "Metabolomic profiling__EFO:0000752", "Protein assay__EFO:0001458"],
+            "enum": ["DNA assay", "RNA assay", "Metabolomic profiling", "Protein assay", "other", "unknown"],
+            "meta:enum": ["DNA assay__EFO:0001456", "RNA assay__EFO:0001457", "Metabolomic profiling__EFO:0000752", "Protein assay__EFO:0001458", "The ID of the assayed molecule is not listed in the controlled vocabulary, and thus you may choose 'other' and propose a new term using the field 'assayed_molecule_label'", "The ID of the assayed molecule is unknown. If possible, provide context of why using the field 'assayed_molecule_label'"],
             "examples": [ "DNA assay" ]
           },
           "assayed_molecule_curie": {
             "type": "string",
-            "title": "Array type of the ArrayExperiment - CURIE",
+            "title": "Assayed molecule of the ArrayExperiment - CURIE",
             "description": "The CURIE (i.e. ontologized term - e.g. EFO:0001456), chosen from a list of CVs, of the assayed molecule.",
             "enum": ["EFO:0001456", "EFO:0001457", "EFO:0000752", "EFO:0001458"],
             "examples": [ "EFO:0001456" ]
+          },
+          "assayed_molecule_label": {
+            "type": "string",
+            "title": "Assayed molecule of the ArrayExperiment - Label",
+            "description": "A free-form label (e.g. 'new unlisted assayed molecule XYZ...') to add any extra information to the assayed molecule of the ArrayExperiment. Specially useful when the assayed_molecule_id is 'other', providing the proposed new assayed molecule term, or 'unknown', explaining the reasoning behind it.",
+            "examples": [ "new unlisted assayed molecule XYZ..." ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "title": "If the assayed_molecule_id is 'other'",
+              "required": ["assayed_molecule_id"],
+              "properties": {
+                "assayed_molecule_id": {
+                  "enum": ["other"]
+                }
+              }
+            },
+            "then": {
+              "title": "Then the assayed_molecule_label has to be present",
+              "required": ["assayed_molecule_label"]
+            }
+          }
+        ]
       },
       
       "adf_files": {

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -98,7 +98,7 @@
             "type": "string",
             "title": "Filename [data:1050]",
             "description": "The full name of a file, including all of their file extensions (e.g. .gpg, .md5...), that identifies the file (e.g. 'my-bam-file.bam.gpg').",
-            "pattern": "^[^<>:;,?\"*|/]+$",
+            "pattern": "^[^<>:;,?\"*|]+$",
             "examples": [ "my-bam-file.bam.gpg" ]
           },
           "filetype": {
@@ -902,7 +902,7 @@
         "type": "string",
         "title": "Filename pattern of a CEL file",
         "description": "This object exists to hold the filename pattern that a 'CEL' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.cel(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.cel(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.cel.gz.gpg" ]
       },
 
@@ -910,7 +910,7 @@
         "type": "string",
         "title": "Filename pattern of a TSV file",
         "description": "This object exists to hold the filename pattern that a 'TSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.tsv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.tsv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.tsv.gz.gpg" ]
       },
 
@@ -918,7 +918,7 @@
         "type": "string",
         "title": "Filename pattern of a ADF file",
         "description": "This object exists to hold the filename pattern that a 'ADF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.adf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.adf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.adf.gz.gpg" ]
       },
 
@@ -926,7 +926,7 @@
         "type": "string",
         "title": "Filename pattern of a FASTQ file",
         "description": "This object exists to hold the filename pattern that a 'FASTQ' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.fastq(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fastq(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.fastq.gz.gpg" ]
       },
 
@@ -934,7 +934,7 @@
         "type": "string",
         "title": "Filename pattern of a FASTA file",
         "description": "This object exists to hold the filename pattern that a 'FASTA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.fasta(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fasta(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.fasta.gz.gpg" ]
       },
 
@@ -942,7 +942,7 @@
         "type": "string",
         "title": "Filename pattern of a SDRF file",
         "description": "This object exists to hold the filename pattern that a 'SDRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.sdrf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sdrf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.sdrf.gz.gpg" ]
       },
 
@@ -950,7 +950,7 @@
         "type": "string",
         "title": "Filename pattern of a IDF file",
         "description": "This object exists to hold the filename pattern that a 'IDF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.idf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.idf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.idf.gz.gpg" ]
       },
 
@@ -958,7 +958,7 @@
         "type": "string",
         "title": "Filename pattern of a VCF file",
         "description": "This object exists to hold the filename pattern that a 'VCF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.vcf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.vcf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.vcf.gz.gpg" ]
       },
 
@@ -966,7 +966,7 @@
         "type": "string",
         "title": "Filename pattern of a SRA file",
         "description": "This object exists to hold the filename pattern that a 'SRA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.sra(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sra(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.sra.gz" ]
       },
 
@@ -974,7 +974,7 @@
         "type": "string",
         "title": "Filename pattern of a SRF file",
         "description": "This object exists to hold the filename pattern that a 'SRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.srf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.srf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.srf.gz.gpg" ]
       },
 
@@ -982,7 +982,7 @@
         "type": "string",
         "title": "Filename pattern of a SFF file",
         "description": "This object exists to hold the filename pattern that a 'SFF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.sff(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sff(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.sff.gz.gpg" ]
       },
 
@@ -990,7 +990,7 @@
         "type": "string",
         "title": "Filename pattern of a BAM file",
         "description": "This object exists to hold the filename pattern that a 'BAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.bam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.bam.arj.gpg" ]
       },
 
@@ -998,7 +998,7 @@
         "type": "string",
         "title": "Filename pattern of a CRAM file",
         "description": "This object exists to hold the filename pattern that a 'CRAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.cram(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.cram(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.cram.gz.gpg" ]
       },
 
@@ -1006,7 +1006,7 @@
         "type": "string",
         "title": "Filename pattern of a XLSX file",
         "description": "This object exists to hold the filename pattern that a 'XLSX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.xlsx(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.xlsx(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.xlsx.tar.gpg" ]
       },
 
@@ -1014,7 +1014,7 @@
         "type": "string",
         "title": "Filename pattern of a CSV file",
         "description": "This object exists to hold the filename pattern that a 'CSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.csv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.csv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.csv" ]
       },
 
@@ -1022,7 +1022,7 @@
         "type": "string",
         "title": "Filename pattern of a BED file",
         "description": "This object exists to hold the filename pattern that a 'BED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.bed(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bed(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.bed.gz.gpg" ]
       },
 
@@ -1030,7 +1030,7 @@
         "type": "string",
         "title": "Filename pattern of a IDAT file",
         "description": "This object exists to hold the filename pattern that a 'IDAT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.idat(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.idat(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.idat.zip" ]
       },
 
@@ -1038,7 +1038,7 @@
         "type": "string",
         "title": "Filename pattern of a MAP file",
         "description": "This object exists to hold the filename pattern that a 'MAP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.map(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.map(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.map.gpg" ]
       },
 
@@ -1046,7 +1046,7 @@
         "type": "string",
         "title": "Filename pattern of a PED file",
         "description": "This object exists to hold the filename pattern that a 'PED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.ped(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.ped(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.ped.gz.gpg" ]
       },
 
@@ -1054,7 +1054,7 @@
         "type": "string",
         "title": "Filename pattern of a BIM file",
         "description": "This object exists to hold the filename pattern that a 'BIM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.bim(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bim(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.bim.gz.gpg" ]
       },
 
@@ -1062,7 +1062,7 @@
         "type": "string",
         "title": "Filename pattern of a FAM file",
         "description": "This object exists to hold the filename pattern that a 'FAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.fam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
         "examples": [ "my_file1.fam.gz.gpg" ]
       },
 


### PR DESCRIPTION
Branch based on EE-2261, so check commits beyond this ID: **only pay attention to those that start with EE-2260**. And please **do ignore changes of JSON schema markdowns** (check commit's name), since these are done automatically when the schemas are modified and encompass hundreds of files.

- [ ] Added 'unknown' and 'other' to some AF fields
- [ ] Added constraints for required optional fields when the main one is 'other'. 

Related ticket: https://www.ebi.ac.uk/panda/jira/browse/EE-2260. 