### PR TITLE
Added bz2 to the compression filename list

### DIFF
--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -922,7 +922,7 @@
         "type": "string",
         "title": "Filename pattern of a CEL file",
         "description": "This object exists to hold the filename pattern that a 'CEL' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.cel(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.cel(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.cel.gz.gpg" ]
       },
 
@@ -930,7 +930,7 @@
         "type": "string",
         "title": "Filename pattern of a TSV file",
         "description": "This object exists to hold the filename pattern that a 'TSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.tsv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.tsv(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tsv.gz.gpg" ]
       },
 
@@ -938,7 +938,7 @@
         "type": "string",
         "title": "Filename pattern of a ADF file",
         "description": "This object exists to hold the filename pattern that a 'ADF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.adf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.adf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.adf.gz.gpg" ]
       },
 
@@ -946,7 +946,7 @@
         "type": "string",
         "title": "Filename pattern of a FASTQ file",
         "description": "This object exists to hold the filename pattern that a 'FASTQ' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.fastq(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fastq(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gz.gpg" ]
       },
 
@@ -954,7 +954,7 @@
         "type": "string",
         "title": "Filename pattern of a FASTA file",
         "description": "This object exists to hold the filename pattern that a 'FASTA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.fasta(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fasta(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fasta.gz.gpg" ]
       },
 
@@ -962,7 +962,7 @@
         "type": "string",
         "title": "Filename pattern of a SDRF file",
         "description": "This object exists to hold the filename pattern that a 'SDRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.sdrf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sdrf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sdrf.gz.gpg" ]
       },
 
@@ -970,7 +970,7 @@
         "type": "string",
         "title": "Filename pattern of a IDF file",
         "description": "This object exists to hold the filename pattern that a 'IDF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.idf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.idf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.idf.gz.gpg" ]
       },
 
@@ -978,7 +978,7 @@
         "type": "string",
         "title": "Filename pattern of a VCF file",
         "description": "This object exists to hold the filename pattern that a 'VCF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.vcf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.vcf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.vcf.gz.gpg" ]
       },
 
@@ -986,7 +986,7 @@
         "type": "string",
         "title": "Filename pattern of a SRA file",
         "description": "This object exists to hold the filename pattern that a 'SRA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.sra(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sra(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sra.gz" ]
       },
 
@@ -994,7 +994,7 @@
         "type": "string",
         "title": "Filename pattern of a SRF file",
         "description": "This object exists to hold the filename pattern that a 'SRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.srf(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.srf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.srf.gz.gpg" ]
       },
 
@@ -1002,7 +1002,7 @@
         "type": "string",
         "title": "Filename pattern of a SFF file",
         "description": "This object exists to hold the filename pattern that a 'SFF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.sff(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.sff(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sff.gz.gpg" ]
       },
 
@@ -1010,7 +1010,7 @@
         "type": "string",
         "title": "Filename pattern of a BAM file",
         "description": "This object exists to hold the filename pattern that a 'BAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.bam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bam(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bam.arj.gpg" ]
       },
 
@@ -1018,7 +1018,7 @@
         "type": "string",
         "title": "Filename pattern of a CRAM file",
         "description": "This object exists to hold the filename pattern that a 'CRAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.cram(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.cram(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.cram.gz.gpg" ]
       },
 
@@ -1026,7 +1026,7 @@
         "type": "string",
         "title": "Filename pattern of a  file",
         "description": "This object exists to hold the filename pattern that a 'XLSX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.xlsx(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.xlsx(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.xlsx.tar.gpg" ]
       },
 
@@ -1034,7 +1034,7 @@
         "type": "string",
         "title": "Filename pattern of a CSV file",
         "description": "This object exists to hold the filename pattern that a 'CSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.csv(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.csv(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.csv" ]
       },
 
@@ -1042,7 +1042,7 @@
         "type": "string",
         "title": "Filename pattern of a BED file",
         "description": "This object exists to hold the filename pattern that a 'BED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.bed(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bed(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bed.gz.gpg" ]
       },
 
@@ -1050,7 +1050,7 @@
         "type": "string",
         "title": "Filename pattern of a IDAT file",
         "description": "This object exists to hold the filename pattern that a 'IDAT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.idat(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.idat(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.idat.zip" ]
       },
 
@@ -1058,7 +1058,7 @@
         "type": "string",
         "title": "Filename pattern of a MAP file",
         "description": "This object exists to hold the filename pattern that a 'MAP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.map(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.map(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.map.gpg" ]
       },
 
@@ -1066,7 +1066,7 @@
         "type": "string",
         "title": "Filename pattern of a PED file",
         "description": "This object exists to hold the filename pattern that a 'PED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.ped(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.ped(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.ped.gz.gpg" ]
       },
 
@@ -1074,7 +1074,7 @@
         "type": "string",
         "title": "Filename pattern of a BIM file",
         "description": "This object exists to hold the filename pattern that a 'BIM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.bim(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.bim(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bim.gz.gpg" ]
       },
 
@@ -1082,7 +1082,7 @@
         "type": "string",
         "title": "Filename pattern of a FAM file",
         "description": "This object exists to hold the filename pattern that a 'FAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^.+\\.fam(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^.+\\.fam(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fam.gz.gpg" ]
       },
 
@@ -1090,7 +1090,7 @@
         "type": "string",
         "title": "Filename pattern of a TXT file",
         "description": "This object exists to hold the filename pattern that a 'TXT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^[^<>:;,?\"*|/]+\\.(txt|TXT)(.gz|.zip|.rar|.arj|.tar|.7z)?(.gpg)?$",
+        "pattern": "^[^<>:;,?\"*|/]+\\.(txt|TXT)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.txt.gz.gpg" ]
       },
 


### PR DESCRIPTION
Based on [@Dona094's comment](https://www.ebi.ac.uk/panda/jira/browse/EE-2244?focusedCommentId=381304&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-381304) I added ``bz2`` to the filename endings, and reformed the regex a bit (although the constraint did not change). 