### PR TITLE
EE-2457 - JSON schema $id pointers to raw text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,7 +22,7 @@ body:
     id: schema-version
     attributes:
       label: Versions
-      description: If the bug is related to the JSON schemas or any tool (e.g. AJV) was used to reproduce the error, plase provide the versions of each here.
+      description: If the bug is related to the JSON schemas or any tool (e.g. AJV) was used to reproduce the error, please provide the versions of each here.
       placeholder:  |
           * Analysis schema v1.2.2
           * Common definitions schema v2.0.0
@@ -44,7 +44,7 @@ body:
     id: observed-behaviour
     attributes:
       label: Observed behaviour
-      description: Please explain what you observed as a bug.
+      description: Please explain the behaviour you observed and considered a bug.
       placeholder: e.g. The description says "Comprises __metadta__..."
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Modified relationship nodes so that only one end of the relationship is allowed [[PR#39](https://github.com/EbiEga/ega-metadata-schema/pull/39)].
 - Modified relationship nodes to accept only specific combinations per object [[PR#39](https://github.com/EbiEga/ega-metadata-schema/pull/39)].
 - Moved and renamed the validation examples from [schemas/validation_tests](./schemas/validation_tests) to [examples/json_validation_tests](./examples/json_validation_tests/) [[PR#42](https://github.com/EbiEga/ega-metadata-schema/pull/42)].
+- Changed cross-schema absolute references to relative ones [PR#44](https://github.com/EbiEga/ega-metadata-schema/pull/44)]
 
 ## [0.0.0] - 2021-04-26
 ### Added [2021-04-26]

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that DAC EGA ID (EGAC) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-DAC-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-DAC-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -60,7 +60,7 @@
           "main_contact": {
             "title": "Main contact of the DAC",
             "description": "The main contact of that DAC whose contact details will be used first to reach the DAC.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/contact_details"
+            "$ref": "./EGA.common-definitions.json#/definitions/contact_details"
           },
           "additional_contacts": {
             "type": "array",
@@ -70,7 +70,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": { 
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/contact_details" 
+              "$ref": "./EGA.common-definitions.json#/definitions/contact_details" 
             }
           }
         }
@@ -87,7 +87,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a DAC",
@@ -97,15 +97,15 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-policy"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -117,23 +117,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-DAC"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-DAC"
                         }
                       ]
                     }
@@ -146,44 +146,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -195,7 +195,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -207,7 +207,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
 

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.DAC.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.DAC.json",
     "type": "object",
     "title": "EGA DAC metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that analysis EGA ID (EGAZ) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-analysis-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-analysis-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -56,7 +56,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/protocols_object" 
+          "$ref": "./EGA.common-definitions.json#/definitions/protocols_object" 
         }
       },
 
@@ -68,7 +68,7 @@
         "uniqueItems": true,
         "additionalProperties": false,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/locus_identifier" 
+          "$ref": "./EGA.common-definitions.json#/definitions/locus_identifier" 
         }
       },
 
@@ -80,7 +80,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
         }
       },
 
@@ -92,7 +92,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
         }
       },
 
@@ -121,7 +121,7 @@
           "reference_alignment_details": {
             "title": "Reference assembly and sequence details",
             "description": "Node containing details of the reference sequence used in the alignment of raw sequences.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/reference_alignment_details"
+            "$ref": "./EGA.common-definitions.json#/definitions/reference_alignment_details"
           }
         }
       },
@@ -134,7 +134,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/file_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/file_object"
         }
       },
 
@@ -149,7 +149,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for an analysis",
@@ -159,31 +159,31 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         }
                       ]
                     }
@@ -195,23 +195,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         }
                       ]
                     }
@@ -224,44 +224,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -273,7 +273,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -285,7 +285,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     }      

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.analysis.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json",
     "type": "object",
     "title": "EGA analysis metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json",
     "type": "object",
     "title": "EGA assay metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that assay's EGA ID (EGAR) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-assay-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-assay-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -62,7 +62,7 @@
         "type": "string",
         "title": "Date of the assay",
         "description": "ISO date (format YYYY-MM-DD - e.g. '2021-05-15') when the sequencing assay took place. If the protocols are long enough, the date shall be the day the assay concluded.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
+        "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
       },
 
       "assay_type_specifications": {
@@ -109,7 +109,7 @@
                 "additionalProperties": false,
                 "uniqueItems": true,
                 "items": { 
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/sample-label-association"
+                  "$ref": "./EGA.common-definitions.json#/definitions/sample-label-association"
                 }
               }
             },
@@ -179,7 +179,7 @@
               "reference_alignment_details": {
                 "title": "Reference assembly and sequence details",
                 "description": "Node containing details of the reference sequence used in the alignment.",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/reference_alignment_details"
+                "$ref": "./EGA.common-definitions.json#/definitions/reference_alignment_details"
               }
             }
           }
@@ -213,7 +213,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for an assay",
@@ -223,24 +223,24 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -252,23 +252,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
                         }
                       ]
                     }
@@ -281,44 +281,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -330,7 +330,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -342,7 +342,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/file_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/file_object"
         }
       },
 
@@ -354,7 +354,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
 

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -41,7 +41,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_external_accession"
+              "$ref": "./EGA.common-definitions.json#/definitions/object_external_accession"
             }
           }
 
@@ -275,7 +275,7 @@
             "allOf": [
               {
                 "title": "Inherited one-relationship-end object", 
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/one-relationship-end" 
+                "$ref": "./EGA.common-definitions.json#/definitions/one-relationship-end" 
               }
             ]
           },
@@ -286,7 +286,7 @@
             "allOf": [
               {
                 "title": "Inherited one-relationship-end object", 
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/one-relationship-end" 
+                "$ref": "./EGA.common-definitions.json#/definitions/one-relationship-end" 
               }
             ]
           },
@@ -395,7 +395,7 @@
                 "allOf": [
                   {
                     "title": "General CURIE pattern",
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                    "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
                   }
                 ],
                 "examples": ["EFO:0005518",  "EFO:0002944",  "EFO:0003813",  "EFO:0003815",  "EFO:0003814",  "EFO:0004184",  "EFO:0003789",  "EFO:0009088", "EFO:0009089", "EFO:0003969", "EFO:0005520", "EFO:0000355", "EFO:0005519", "EFO:0003788", "EFO:0000395", "EFO:0010892", "EFO:0010214"]
@@ -485,7 +485,7 @@
               "allOf": [
                 {
                   "title": "General pattern of a CURIE",
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                  "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
                 }
               ],
               "examples": [ "CHEBI:37987" ]
@@ -1258,7 +1258,7 @@
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
               }
             ],
             "examples": [ "biosample:SAMEA7616999", "arrayexpress:E-MEXP-1712", "biostudies:S-EPMC3314381"]
@@ -1281,7 +1281,7 @@
         "properties": {
           "label": { 
             "title": "Labelling dye used with the sample",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/array_label" 
+            "$ref": "./EGA.common-definitions.json#/definitions/array_label" 
           },
           "object_id": {
             "type": "object",
@@ -1289,13 +1289,13 @@
             "allOf": [
               {
                 "title": "Inherited object_core_id object",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+                "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
               },
               {
                 "title": "Check that sample EGA ID (EGAN) pattern is correct",
                 "properties": {
                   "ega_accession": {
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
+                    "$ref": "./EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
                   }
                 }
               }
@@ -1318,7 +1318,7 @@
             "allOf": [
               { 
                 "title": "Inherited object_core_id object", 
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id" 
+                "$ref": "./EGA.common-definitions.json#/definitions/object_core_id" 
               }
             ]
           },
@@ -1347,7 +1347,7 @@
         "allOf": [
           { 
             "title": "Check for object_id and object_type to match",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object-id-and-object-type-check" 
+            "$ref": "./EGA.common-definitions.json#/definitions/object-id-and-object-type-check" 
           }
         ]        
       },
@@ -1397,7 +1397,7 @@
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
               }
             ]
           },
@@ -1473,7 +1473,7 @@
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
               }
             ]
           },
@@ -1484,7 +1484,7 @@
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
               }
             ]
           }
@@ -1614,7 +1614,7 @@
           "organism_descriptor": {
             "title": "Organism descriptor",
             "description": "Node to identify the specific organism the locus belongs to.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/organism_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
           },
           "loci_descriptor": {
             "type": "array",
@@ -1631,17 +1631,17 @@
                 "gene_descriptor": {
                   "title": "Gene descriptor",
                   "description": "Node to identify the gene of the locus of interest.",
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/gene_descriptor"
+                  "$ref": "./EGA.common-definitions.json#/definitions/gene_descriptor"
                 },
                 "genomic_sequence_descriptor": {
                   "title": "Genomic sequence descriptor",
                   "description": "Node to describe the sequence per se, instead of referencing it.",
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/genomic_sequence_descriptor"
+                  "$ref": "./EGA.common-definitions.json#/definitions/genomic_sequence_descriptor"
                 },
                 "locus_external_reference": {
                   "title": "External reference of the locus",
                   "description": "If the locus is NOT a gene (if so, use 'gene_descriptor'), and it is well represented (i.e. uniquely identifiable and with comprehensive detail) in another resource that is accessible and persistent, one can reference it here instead of providing all their details. For example, transcript TAF1-204 already contains all its locus information within its persistent record at Ensembl, identified by 'ensembl:ENST00000423759.6'.",
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_external_accession",
+                  "$ref": "./EGA.common-definitions.json#/definitions/object_external_accession",
                   "examples": ["ensembl:ENST00000423759.6"]
                 },
                 "locus_additional_description": {
@@ -1694,17 +1694,17 @@
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
               }
             ],
             "oneOf": [
               {
                 "title": "NCBI Gene pattern (e.g. 'NCBIGene:100010')",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_ncbi_gene_identifier_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_ncbi_gene_identifier_pattern"
               },
               {
                 "title": "NCBI Gene pattern (e.g. 'NCBIGene:100010')",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_hgnc_identifier_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_hgnc_identifier_pattern"
               }
             ],
             "examples": ["HGNC:11535", "hgnc:11998", "HGNC:1097", "ncbigene:100010", "ncbigene:6872"]
@@ -1734,7 +1734,7 @@
             "allOf": [
               {
                 "title": "Assembly's CURIE pattern",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_ncbi_assembly_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_ncbi_assembly_pattern"
               }
             ],
             "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
@@ -1754,7 +1754,7 @@
             "allOf": [
               {
                 "title": "RefSeq accession CURIE",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_refseq_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_refseq_pattern"
               }
             ],
             "examples": ["refseq:NC_000001.11", "refseq:NC_012920.1"]
@@ -1784,20 +1784,20 @@
             "title": "Assembly descriptor",
             "meta:property_curie": "topic:0196",
             "description": "Node to identify the assembly of the locus of interest.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
           },
           "sequence_coordinates": {
             "title": "DNA Sequence coordinates",
             "description": "Node to define que specific sequence coordinates of the genomic feature within the assembly.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/sequence_coordinates"
+            "$ref": "./EGA.common-definitions.json#/definitions/sequence_coordinates"
           },
           "dna_sequence_strand": {
             "title": "DNA Sequence strand",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/dna_sequence_strand"
+            "$ref": "./EGA.common-definitions.json#/definitions/dna_sequence_strand"
           },
           "nucleic_acid_sequence": {
             "title": "Nucleic acid sequence of the locus",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/nucleic_acid_sequence"
+            "$ref": "./EGA.common-definitions.json#/definitions/nucleic_acid_sequence"
           }
         },
         "anyOf": [
@@ -1821,7 +1821,7 @@
         "properties": {
           "single_position": {
             "title": "Single position",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/single_sequence_position"
+            "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
           },
           "sequence_interval": {
             "type": "object",
@@ -1833,11 +1833,11 @@
             "properties": {
               "start": {
                 "title": "Start position",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/single_sequence_position"
+                "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
               },
               "end": {
                 "title": "End position",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/single_sequence_position"
+                "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
               }
             }
           }
@@ -1898,7 +1898,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
           }
         ],        
         "oneOf": [
@@ -1989,7 +1989,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
           }
         ],
         "examples": ["hgnc.symbol:DAPK1", "hgnc.symbol:TAF1"]
@@ -2003,7 +2003,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
           }
         ],
         "examples": ["hgnc:2674", "HGNC:11535"]
@@ -2017,7 +2017,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
           }
         ],
         "examples": ["ncbigene:100010", "ncbigene:270627"]
@@ -2031,7 +2031,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
           }
         ],
         "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
@@ -2072,7 +2072,7 @@
                 "enum": [ "array" ]
               },
               "assay_instrument_platform": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json"
               }
             }              
           },
@@ -2083,7 +2083,7 @@
                 "enum": [ "sequencer" ]
               },
               "assay_instrument_platform": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json"
               }
             }              
           }
@@ -2298,7 +2298,7 @@
         "minItems": 1,
         "items": {
           "title": "One item containing metadata of the assembly or assembly unit.",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
+          "$ref": "./EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
         }
       },
 
@@ -2764,10 +2764,10 @@
         "description": "This node defines a relationship item containing a 'submission' as a source and of type 'referenced_by'. This node can be used with the keyword 'contains' at each relationship array of all objects (but submission), in order to assert that all objects have a submission object (EGAB...) linked to them.",
         "allOf": [
           {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+            "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
           },
           {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+            "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
           }
         ]
       }

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
     "type": "object",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json",
     "title": "EGA common metadata definitions",
     "meta:version": "0.0.0",
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to store common definitions for other metadata objects. Basically, we are defining here common properties (e.g. instances' aliases) that other metadata objects (e.g. sample) may use. The way we refer to them is by using this object's '$id' field, referencing it in other files (with '$ref' and the relative path of the property - e.g. '$ref': 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id'). See structuring documentation (https://json-schema.org/understanding-json-schema/structuring.html). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.dataset.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.dataset.json",
     "type": "object",
     "title": "EGA dataset metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that dataset EGA ID (EGAD) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-dataset-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-dataset-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -80,7 +80,7 @@
         "allOf": [
           {
             "title": "The date has to match the common date pattern",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
           },
           {
             "title": "We cap the reminder up to 3 years",
@@ -101,7 +101,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a dataset",
@@ -111,21 +111,21 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-policy"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -137,23 +137,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-dataset"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
                         }
                       ]
                     }
@@ -166,44 +166,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -215,7 +215,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -227,7 +227,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
       

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that experiment EGA ID (EGAX) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-experiment-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-experiment-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -56,7 +56,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/protocols_object" 
+          "$ref": "./EGA.common-definitions.json#/definitions/protocols_object" 
         }
       },
 
@@ -68,14 +68,14 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/locus_identifier" 
+          "$ref": "./EGA.common-definitions.json#/definitions/locus_identifier" 
         }
       },
 
       "assay_technology": {
         "title": "Technology used in the assay",
         "description": "Technology used in the assay. This node allows for an easy filtering of the technology (e.g. a sequencer Illumina NextSeq 500) used to obtain the raw data (e.g. sequence files) in an assay.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/assay_technology_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/assay_technology_descriptor"
       },
 
       "assay_type_descriptor": {
@@ -93,11 +93,11 @@
             "anyOf": [
               {
                 "title": "Array-assay type controlled vocabulary (CV) list",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json"
               },
               {
                 "title": "Sequencer-assay type controlled vocabulary (CV) list",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json"
               }
             ],
             "examples": [ "Hi-C", "amplicon sequencing", "assay by high throughput sequencer", "immune sequencing", "ChIP-chip by array", "transcription profiling by array", "microRNA profiling by array", "genotyping by array", "comparative genomic hybridization by array" ]
@@ -117,11 +117,11 @@
                 "anyOf": [
                   {
                     "title": "DNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json"
                   },
                   {
                     "title": "RNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json"
                   }
                 ]                 
               }
@@ -134,10 +134,10 @@
                 "title": "Assay type and subtype terms are from the array CV list",
                 "properties": {
                   "assay_type": {
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json" 
                   },
                   "assay_subtype": {
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json" 
                   }
                 }
               },
@@ -145,10 +145,10 @@
                 "title": "Assay type and subtype terms are from the sequencer CV list",
                 "properties": {
                   "assay_type": {
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json" 
                   },
                   "assay_subtype": {
-                    "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json" 
                   }
                 }
               }
@@ -188,7 +188,7 @@
         "description": "Types of data the experiment produces.",
         "uniqueItems": true,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
         }
       },
 
@@ -214,7 +214,7 @@
                 "uniqueItems": true,
                 "minItems": 1,
                 "items": {
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/array_label" 
+                  "$ref": "./EGA.common-definitions.json#/definitions/array_label" 
                 }
               },
               
@@ -227,7 +227,7 @@
                 "uniqueItems": true,
                 "items": {
                   "title": "ADF File object",
-                  "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/file_object" 
+                  "$ref": "./EGA.common-definitions.json#/definitions/file_object" 
                 }
               }
             }
@@ -241,12 +241,12 @@
             "properties": {
               "library_layout": {
                 "title": "Library layout of the sequencing experiment",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/library_layout"
+                "$ref": "./EGA.common-definitions.json#/definitions/library_layout"
               },
               "spot_descriptor": {
                 "title": "Spot descriptor of the sequencing experiment",
                 "description": "Adapted from current ENA's XSDs without improvements. #! Expected to be investigated.",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/spot_descriptor"
+                "$ref": "./EGA.common-definitions.json#/definitions/spot_descriptor"
               }
             }
           }
@@ -274,7 +274,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for an experiment",
@@ -284,33 +284,33 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
-                        },
-                        {
-                          "title": "Optional one, added here to simplify",
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
+                        },
+                        {
+                          "title": "Optional one, added here to simplify",
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
                         }
                       ]
                     }
@@ -322,23 +322,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
                         }
                       ]
                     }
@@ -351,44 +351,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -400,7 +400,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -412,7 +412,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     },

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.experiment.json",
     "type": "object",
     "title": "EGA Experiment metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.individual.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.individual.json",
     "type": "object",
     "title": "EGA individual metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that individual EGA ID (EGAI) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-individual-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-individual-id-pattern"
               }
             }
           }
@@ -31,11 +31,11 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "organism_descriptor": {
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/organism_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
       },
      
       "minimal_public_attributes":{
@@ -46,13 +46,13 @@
         "required": ["subject_id", "biological_sex", "phenotype"],
         "properties": {
           "subject_id": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/subject_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/subject_id"
           },
           "biological_sex": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/biological_sex"
+            "$ref": "./EGA.common-definitions.json#/definitions/biological_sex"
           },
           "phenotype": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/experimental_condition_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/experimental_condition_descriptor"
           }
         }
       },
@@ -68,7 +68,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for an individual",
@@ -78,15 +78,15 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -98,26 +98,26 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-individual"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-individual"
                         }
                       ]
                     }
@@ -130,44 +130,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -179,7 +179,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -191,7 +191,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     }

--- a/schemas/EGA.object-set.json
+++ b/schemas/EGA.object-set.json
@@ -12,7 +12,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_array": {
@@ -36,7 +36,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json#"
+              "$ref": "./EGA.experiment.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an study",
@@ -48,7 +48,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.study.json#"
+              "$ref": "./EGA.study.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an sample",
@@ -60,7 +60,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json#"
+              "$ref": "./EGA.sample.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an individual",
@@ -72,7 +72,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.individual.json#"
+              "$ref": "./EGA.individual.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an submission",
@@ -84,7 +84,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.submission.json#"
+              "$ref": "./EGA.submission.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an dataset",
@@ -96,7 +96,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.dataset.json#"
+              "$ref": "./EGA.dataset.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an analysis",
@@ -108,7 +108,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.analysis.json#"
+              "$ref": "./EGA.analysis.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an policy",
@@ -120,7 +120,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.policy.json#"
+              "$ref": "./EGA.policy.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an DAC",
@@ -132,7 +132,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.DAC.json#"
+              "$ref": "./EGA.DAC.json#"
             },
             {
               "title": "The object's 'schema_descriptor' defines it as an assay",
@@ -144,7 +144,7 @@
                   }
                 }
               },
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json#"
+              "$ref": "./EGA.assay.json#"
             }
           ]      
         }

--- a/schemas/EGA.object-set.json
+++ b/schemas/EGA.object-set.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.object-set.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.object-set.json",
     "type": "object",
     "title": "EGA object-set metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.policy.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.policy.json",
     "type": "object",
     "title": "EGA policy metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that policy EGA ID (EGAP) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-policy-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-policy-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -94,7 +94,7 @@
           "allOf": [
             {
               "title": "General pattern of a CURIE",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+              "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
             }
           ]
         }
@@ -111,7 +111,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a policy",
@@ -121,18 +121,18 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-DAC"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -144,20 +144,20 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-policy"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-policy"
                         }
                       ]
                     }
@@ -170,44 +170,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -219,7 +219,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -231,7 +231,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     }      

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that sample EGA ID (EGAN) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -49,7 +49,7 @@
       },
 
       "organism_descriptor": {
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/organism_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
       },
       
       "minimal_public_attributes":{
@@ -60,13 +60,13 @@
         "required": ["subject_id", "biological_sex", "experimental_condition"],
         "properties": {
           "subject_id": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/subject_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/subject_id"
           },
           "biological_sex": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/biological_sex"
+            "$ref": "./EGA.common-definitions.json#/definitions/biological_sex"
           },
           "experimental_condition": {
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/experimental_condition_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/experimental_condition_descriptor"
           }
         }
       },
@@ -83,14 +83,14 @@
             "title": "Date of the sample collection",
             "meta:property_curie": "EFO:0000689",
             "description": "ISO date (format YYYY-MM-DD - e.g. '2021-05-15') when the sample was collected. If the protocols are long enough, the date shall be the day the collection concluded.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO-date-YYYY-MM-DD-pattern"
           },
           "sample_collection_site": {
             "type": "string",
             "title": "Sampling site",
             "meta:property_curie": "EFO:0000688",
             "description": "A site from which a sample, i.e. a statistically representative of the whole, is extracted from the whole. The ontology to use is UBERON's anatomical entity [UBERON:0001062]. Search for your sample collection site at http://purl.obolibrary.org/obo/UBERON_0001062. For example, in the case of a nasal swab, it would be 'nasal cavity'; in a liver biopsy it would be 'liver'.",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/uberon-anatomical-entity",
+            "$ref": "./EGA.common-definitions.json#/definitions/uberon-anatomical-entity",
             "examples": ["nasal cavity", "liver", "gut wall", "oral cavity" ]
           },
           "sample_collection_site_curie": {
@@ -102,7 +102,7 @@
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
               }
             ]
           }          
@@ -184,7 +184,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a sample",
@@ -194,25 +194,25 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         },
                         { 
                           "title": "Optional one, added here to simplify",
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-individual"
                         }
                       ]
                     }
@@ -224,26 +224,26 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
                         }
                       ]
                     }
@@ -256,44 +256,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -305,7 +305,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -317,7 +317,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     }

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -1,6 +1,6 @@
   {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.sample.json",
     "type": "object",
     "title": "EGA sample metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.study.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.study.json",
     "type": "object",
     "title": "EGA study metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that study EGA ID (EGAS) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-study-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-study-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -89,7 +89,7 @@
         "minItems": 1,
         "items": {
           "title": "One study design",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/study-design-keywords"
+          "$ref": "./EGA.common-definitions.json#/definitions/study-design-keywords"
         }
       },
 
@@ -104,7 +104,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a study",
@@ -114,18 +114,18 @@
                   "title": "Allowed relationships of type referenced_by (main ones)",
                   "allOf": [
                     {
-                      "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         }
                       ]
                     }
@@ -137,23 +137,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-study"
                         }
                       ]
                     }
@@ -166,44 +166,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -215,7 +215,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
         }
       },
 
@@ -227,7 +227,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }      
     }      

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -15,13 +15,13 @@
         "allOf": [
           {
             "title": "Inherited object_core_id object",
-            "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id"
+            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
           },
           {
             "title": "Check that Submission EGA ID (EGAB) is correct",
             "properties": {
               "ega_accession": {
-                "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/EGA-submission-id-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGA-submission-id-pattern"
               }
             }
           }
@@ -31,7 +31,7 @@
       "schema_descriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
       },
 
       "object_title": {
@@ -75,7 +75,7 @@
               }
             },
             "collaborator_contact_details": {
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/contact_details"
+              "$ref": "./EGA.common-definitions.json#/definitions/contact_details"
             }
           }
         }
@@ -92,7 +92,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
             },
             {
               "title": "Relationship constraints for a submission",
@@ -104,23 +104,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-submission"
                         }
                       ]
                     }
@@ -133,41 +133,41 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
                         },
                         {
-                          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
                         }
                       ]
                     }
@@ -187,7 +187,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
         }
       }
     }      

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.submission.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.submission.json",
     "type": "object",
     "title": "EGA submission metadata schema",
     "meta:version": "0.0.0",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -54,12 +54,15 @@ In case these schemas need to be modified, in this section you will find listed 
     { "$ref": "#/definitions/md5-checksum-pattern" }
     ````
 
-    2. **Different-file shared definitions**. The way these cross-file references are achieved is by using the IDs of the schemas (``$id`` within its first layer) and object's anchors (_e.g._ ``"EGA-sample-id-pattern``), which point to the objects within the files, turning them into references (``$ref`` wherever they are needed). See [Structuring a complex schema]
-    (https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``object_coreIDs`` within ``definitions`` of the ``EGA.common-definitions.json`` and then referenced it within the ``experiment.json`` (notice how this time the JSON pointer contains the whole ``$id`` instead of being relative):
+    2. **Different-file shared definitions**. The way these cross-file references are achieved is by using the IDs of the schemas (``$id`` within its first layer) and object's anchors (_e.g._ ``"EGA-sample-id-pattern``), which point to the objects within the files, turning them into references (``$ref`` wherever they are needed). References are resolved against the absolute URL identifiers of the 
+    schemas. In other words, a relative reference ($ref; e.g. ``./EGA.common-definitions.json#...``) is put against the absolute identifier (``$id``; e.g. ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json``) of the referencing schema (in this example ``EGA.analysis.json``), transforming the relative reference into an absolute one (e.g. 
+    ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json#...``). See 
+    [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``object_coreIDs`` within ``definitions`` of the ``EGA.common-definitions.json`` and then referenced it within the ``experiment.json`` (notice how this time the JSON 
+    pointer contains the whole ``$id`` instead of being relative):
     ````
     # Simplified common schema
     {
-        "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json",
+        "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
         "definitions": {
             "object_coreIDs": {
                 ...
@@ -68,13 +71,13 @@ In case these schemas need to be modified, in this section you will find listed 
 
     # Simplified experiment schema with a reference to the object_coreIDs:
     {
-        "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json",
+        "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.experiment.json",
         "properties": {
             "object_ids": {
                 "type": "object",
                 "allOf": [
                     {
-                        "$ref": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_coreIDs"
+                        "$ref": "./EGA.common-definitions.json#/definitions/object_coreIDs"
                     }
                 ]
             }

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json",
     "title": "EGA Controlled Vocabulary (CV) for assay subtypes by array [EFO:0002696]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay subtypes by array: any ontologized term for a subtype (i.e. child ontology) of an array assay [EFO:0002696]. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json",
     "title": "EGA Controlled Vocabulary (CV) for assay subtypes by DNA [EFO:0001456]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay subtypes by the assayed molecule being DNA: any ontologized term for a subtype (i.e. child ontology) of a DNA assay [EFO:0001456]. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json",
     "title": "EGA Controlled Vocabulary (CV) for assay subtypes by RNA [EFO:0001457]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay subtypes by the assayed molecule being RNA: any ontologized term for a subtype (i.e. child ontology) of a RNA assay [EFO:0001457]. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json",
     "title": "EGA Controlled Vocabulary (CV) for assay subtypes by sequencer [EFO:0003740]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay subtypes by sequencer: any ontologized term for a subtype (i.e. child ontology) of an sequencing assay [EFO:0003740]. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json",
     "title": "EGA Controlled Vocabulary (CV) for assay types by array [EFO:0002696]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay types by array [EFO:0002696]: an assay that exploits an array as the instrument to find results. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json",
     "title": "EGA Controlled Vocabulary (CV) for assay types by sequencer [EFO:0003740]",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for assay types by sequencer [EFO:0003740]: an assay that exploits a sequencer as the instrument to find results. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json",
     "title": "EGA Controlled Vocabulary (CV) for array instrument platforms",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for the array instrument platforms, derived from Array Express and Gene Expression Omnibus. Commonly consisting in the manufacturers name (e.g. Affymetrix) and the instrument model (e.g. Human CentXbaAv2 SNP Array). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",

--- a/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json
+++ b/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "string",
-    "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json",
+    "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json",
     "title": "EGA Controlled Vocabulary (CV) for sequencing instrument platforms",
     "meta:version": "0.0.0",
     "description": "Controlled Vocabulary (CV) list for the sequencing instrument platforms. Commonly consisting in the manufacturers name (e.g. Illumina) and the instrument model (e.g. HiSeq 2000). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",


### PR DESCRIPTION
## Ticket reference
EE-2457

## Overall changes
- [x] Changed all JSON schema pointers (``$id``) for them to point to the raw text version of each file. So basically instead of ``https://github.com/EbiEga/ega-metadata-schema/blob/main/schemas/EGA.assay.json`` having ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json``, which allows for any service to grab those schemas and relative references to work. 
- [x] Updated documentation.

## Future TO-DOs
- [ ] Add to CHANGELOG
- [ ] Test, once merged with the main branch, that retrieval of the schemas (i.e. references) through the updated $ids work
