### PR TITLE
EEH-2468 - Refactor naming conventions (lowerCamelCase)

### DIFF
--- a/examples/json_validation_tests/DAC_valid-1.json
+++ b/examples/json_validation_tests/DAC_valid-1.json
@@ -1,73 +1,73 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.DAC.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "my_DAC_X10", 
-            "center_name" : "EBI-TEST",
-            "ega_accession": "EGAC00000000001"
-        },
-        "object_title": "EBI test DAC",
-        "object_description": "A example DAC used exclusively for testing.",
-        "dac_contacts": {
-            "main_contact": {
-                "individual_full_name": "Wayne Jr., Bruce",
-                "institution_name": "European Bioinformatics Institute (EBI)",
-                "email_address": "myname@ebi.ac.uk",
-                "phone_number": "+44 7427512529"
-            },
-            "additional_contacts": [
-                {
-                    "individual_full_name": "Todd, Jason",
-                    "email_address": "myname2@ebi.ac.uk"
-                },
-                {
-                    "institution_name": "BAT-CAVE",
-                    "email_address": "myname3@ebi.ac.uk"
-                }
-            ]
-        },
-        "dac_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAP00002045411"
-                    },
-                    "object_type": "policy"                 
-                }
-            },
-            {
-                "r_type": "same_as",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAC00002344532"
-                    },
-                    "object_type": "DAC"                 
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "dac_attributes": [
+        "dacAttributes": [
             {
                 "tag": "Associated project ID",
-                "value": "X33981-DGH"            
+                "value": "X33981-DGH"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "DAC",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.DAC.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "dacContacts": {
+            "additionalContacts": [
+                {
+                    "emailAddress": "myname2@ebi.ac.uk",
+                    "individualFullName": "Todd, Jason"
+                },
+                {
+                    "emailAddress": "myname3@ebi.ac.uk",
+                    "institutionName": "BAT-CAVE"
+                }
+            ],
+            "mainContact": {
+                "emailAddress": "myname@ebi.ac.uk",
+                "individualFullName": "Wayne Jr., Bruce",
+                "institutionName": "European Bioinformatics Institute (EBI)",
+                "phoneNumber": "+44 7427512529"
+            }
+        },
+        "dacRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAP00002045411"
+                    },
+                    "objectType": "policy"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAC00002344532"
+                    },
+                    "objectType": "DAC"
+                },
+                "rType": "same_as"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "objectDescription": "A example DAC used exclusively for testing.",
+        "objectId": {
+            "alias": "my_DAC_X10",
+            "centerName": "EBI-TEST",
+            "egaAccession": "EGAC00000000001"
+        },
+        "objectTitle": "EBI test DAC",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.DAC.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "DAC"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.DAC.json"
     }
 }

--- a/examples/json_validation_tests/DAC_valid-1.json
+++ b/examples/json_validation_tests/DAC_valid-1.json
@@ -32,7 +32,7 @@
                     },
                     "objectType": "policy"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -41,7 +41,7 @@
                     },
                     "objectType": "DAC"
                 },
-                "rType": "same_as"
+                "rType": "sameAs"
             },
             {
                 "rSource": {
@@ -50,7 +50,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "objectDescription": "A example DAC used exclusively for testing.",

--- a/examples/json_validation_tests/analysis_valid-1.json
+++ b/examples/json_validation_tests/analysis_valid-1.json
@@ -1,142 +1,145 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "Sequencing_analysis_13", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "Example VCF analysis",
-        "object_description": "Sequenced reads of 120 human patients (79 controls vs 41 cases) were aligned against the human referenced and then extracted sequence variation... ...VCF files were compared along patients' clinical histories.",
-        "types_of_input_data": [
-            "genomic data"
-        ],
-        "types_of_output_data": [
-            "processed sequencing data"
-        ],
-        "analysis_type_specifications": {
-            "analysis_types": [ "sequence variation", "phenotype characterization" ],
-            "reference_alignment_details": [
-                {
-                    "assembly_name": "GRCh38.p14",
-                    "ncbi_assembly_accession": "assembly:GCA_000001405.29"
-                }
-            ]
-        },
-        "targeted_loci": [
+        "analysisAttributes": [
             {
-                "organism_descriptor": {
-                    "taxon_id_curie": "NCBITaxon:9606",
-                    "scientific_name": "homo sapiens"
-                },
-                "loci_descriptor": [
-                    {
-                        "gene_descriptor": {
-                            "gene_symbol": "TP53",
-                            "gene_id_curie": "HGNC:11998"
-                        },
-                        "locus_additional_description": "Variation within the VCF corresponds to TP53 variation among patients."
-                    }
-                ]
-            }
-        ],
-        "analysis_files": [
-            {
-                "filename": "sequence_variation.vcf.gpg",
-                "filetype": "VCF",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "9a4249e4b0538b9789c5d7f25d6342f0",
-                "encrypted_checksum": "c6779ec2960296ed9a04f08d67fa4415"
-            },
-            {
-                "filename": "analysis_script.py.gpg",
-                "filetype": "PY",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "e8c111e482c9ca49967497fecd988fe9",
-                "encrypted_checksum": "d92463599ed4548cfa4fff55c1b48d7e"
-            }
-        ],
-        "analysis_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAS00002045411"
-                    },
-                    "object_type": "study"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAZ00001051423"
-                    },
-                    "object_type": "analysis"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAX00001051423"
-                    },
-                    "object_type": "experiment"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031671",
-                        "alias": "Genome indexing protocol"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031672",
-                        "alias": "Read mapping protocol"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031673",
-                        "alias": "Variant calling protocol"
-                    },
-                    "object_type": "protocol"
-                },
-                "r_label": "Differed from the general protocol by using parameters X and Y with values ..."
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "analysis_attributes": [
-            {            
                 "tag": "sub_project",
                 "value": "CB4-1UD"
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "analysis",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.analysis.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
-        }
+        ],
+        "analysisFiles": [
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "c6779ec2960296ed9a04f08d67fa4415",
+                "filename": "sequence_variation.vcf.gpg",
+                "filetype": "VCF",
+                "unencryptedChecksum": "9a4249e4b0538b9789c5d7f25d6342f0"
+            },
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "d92463599ed4548cfa4fff55c1b48d7e",
+                "filename": "analysis_script.py.gpg",
+                "filetype": "PY",
+                "unencryptedChecksum": "e8c111e482c9ca49967497fecd988fe9"
+            }
+        ],
+        "analysisRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAS00002045411"
+                    },
+                    "objectType": "study"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAZ00001051423"
+                    },
+                    "objectType": "analysis"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAX00001051423"
+                    },
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Genome indexing protocol",
+                        "egaAccession": "EGAO00001031671"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Read mapping protocol",
+                        "egaAccession": "EGAO00001031672"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
+                "rSource": {
+                    "objectId": {
+                        "alias": "Variant calling protocol",
+                        "egaAccession": "EGAO00001031673"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "analysisTypeSpecifications": {
+            "analysisTypes": [
+                "sequence variation",
+                "phenotype characterization"
+            ],
+            "referenceAlignmentDetails": [
+                {
+                    "assemblyName": "GRCh38.p14",
+                    "ncbiAssemblyAccession": "assembly:GCA_000001405.29"
+                }
+            ]
+        },
+        "objectDescription": "Sequenced reads of 120 human patients (79 controls vs 41 cases) were aligned against the human referenced and then extracted sequence variation... ...VCF files were compared along patients' clinical histories.",
+        "objectId": {
+            "alias": "Sequencing_analysis_13",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "Example VCF analysis",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.analysis.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "analysis"
+        },
+        "targetedLoci": [
+            {
+                "lociDescriptor": [
+                    {
+                        "geneDescriptor": {
+                            "geneIdCurie": "HGNC:11998",
+                            "geneSymbol": "TP53"
+                        },
+                        "locusAdditionalDescription": "Variation within the VCF corresponds to TP53 variation among patients."
+                    }
+                ],
+                "organismDescriptor": {
+                    "scientificName": "homo sapiens",
+                    "taxonIdCurie": "NCBITaxon:9606"
+                }
+            }
+        ],
+        "typesOfInputData": [
+            "genomic data"
+        ],
+        "typesOfOutputData": [
+            "processed sequencing data"
+        ]
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json"
     }
 }

--- a/examples/json_validation_tests/analysis_valid-1.json
+++ b/examples/json_validation_tests/analysis_valid-1.json
@@ -30,7 +30,7 @@
                     },
                     "objectType": "study"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -39,7 +39,7 @@
                     },
                     "objectType": "analysis"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -48,7 +48,7 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -58,7 +58,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -68,7 +68,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
@@ -79,7 +79,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -88,7 +88,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "analysisTypeSpecifications": {

--- a/examples/json_validation_tests/assay_valid-1_array.json
+++ b/examples/json_validation_tests/assay_valid-1_array.json
@@ -37,7 +37,7 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -46,7 +46,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "assayTypeSpecifications": {

--- a/examples/json_validation_tests/assay_valid-1_array.json
+++ b/examples/json_validation_tests/assay_valid-1_array.json
@@ -1,93 +1,93 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "My_array_assay_M3051057", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "Breast cancer array assay M3051057",
-        "assay_center": "EBI-TEST",
-        "assay_date": "2022-02-13",
-        "assay_type_specifications": {
-            "assay_type": "array",
-            "array_assay_specifications": {
-                "n_labels_per_array": 2,
-                "array_sample_labels": [
-                    {
-                        "label": {
-                            "array_label_id": "Cy3",
-                            "array_label_curie": "CHEBI:37987"
-                        },
-                        "object_id": {
-                            "ega_accession": "EGAN00002094401"
-                        }
-                    },
-                    {
-                        "label": {
-                            "array_label_id": "Cy5",
-                            "array_label_curie": "CHEBI:37989"
-                        },
-                        "object_id": {
-                            "ega_accession": "EGAN00002094453"
-                        }
-                    }
-                ]
-            }
-        },
-        "assay_files": [
-            {
-                "filename": "myfile1_M3051057.cel.gpg",
-                "filetype": "CEL",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "9a4249e4b0538b9789c5d7f25d6342f0",
-                "encrypted_checksum": "c6779ec2960296ed9a04f08d67fa4415"
-            },
-            {
-                "filename": "myfile2_M3051057.cel.gpg",
-                "filetype": "CEL",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "e8c111e482c9ca49967497fecd988fe9",
-                "encrypted_checksum": "d92463599ed4548cfa4fff55c1b48d7e"
-            }
-        ],
-        "assay_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAX00002094401"
-                    },
-                    "object_type": "experiment"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],    
-        "assay_attributes": [
+        "assayAttributes": [
             {
                 "tag": "weather",
                 "value": "When the assay was executed it was sunny outside"
             },
             {
                 "tag": "assay price",
-                "value": 200,
-                "units": "euros"
+                "units": "euros",
+                "value": 200
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "assay",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        ],
+        "assayCenter": "EBI-TEST",
+        "assayDate": "2022-02-13",
+        "assayFiles": [
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "c6779ec2960296ed9a04f08d67fa4415",
+                "filename": "myfile1_M3051057.cel.gpg",
+                "filetype": "CEL",
+                "unencryptedChecksum": "9a4249e4b0538b9789c5d7f25d6342f0"
+            },
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "d92463599ed4548cfa4fff55c1b48d7e",
+                "filename": "myfile2_M3051057.cel.gpg",
+                "filetype": "CEL",
+                "unencryptedChecksum": "e8c111e482c9ca49967497fecd988fe9"
+            }
+        ],
+        "assayRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAX00002094401"
+                    },
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "assayTypeSpecifications": {
+            "arrayAssaySpecifications": {
+                "arraySampleLabels": [
+                    {
+                        "label": {
+                            "arrayLabelCurie": "CHEBI:37987",
+                            "arrayLabelId": "Cy3"
+                        },
+                        "objectId": {
+                            "egaAccession": "EGAN00002094401"
+                        }
+                    },
+                    {
+                        "label": {
+                            "arrayLabelCurie": "CHEBI:37989",
+                            "arrayLabelId": "Cy5"
+                        },
+                        "objectId": {
+                            "egaAccession": "EGAN00002094453"
+                        }
+                    }
+                ],
+                "nLabelsPerArray": 2
+            },
+            "assayType": "array"
+        },
+        "objectId": {
+            "alias": "My_array_assay_M3051057",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "Breast cancer array assay M3051057",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "assay"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json"
     }
 }

--- a/examples/json_validation_tests/assay_valid-2_sequencing.json
+++ b/examples/json_validation_tests/assay_valid-2_sequencing.json
@@ -37,7 +37,7 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -46,7 +46,7 @@
                     },
                     "objectType": "analysis"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -55,7 +55,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "assayTypeSpecifications": {

--- a/examples/json_validation_tests/assay_valid-2_sequencing.json
+++ b/examples/json_validation_tests/assay_valid-2_sequencing.json
@@ -1,93 +1,93 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "My_sequencing_assay_M305004", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "Breast cancer sequencing assay M305004",
-        "assay_center": "EBI-TEST",
-        "assay_date": "2022-02-13",
-        "assay_type_specifications": {
-            "assay_type": "sequencing",
-            "sequencing_assay_specifications": {
-                "reference_alignment_details": [
-                    {
-                        "assembly_name": "GRCh38.p14",
-                        "ncbi_assembly_accession": "assembly:GCF_000001405.26",
-                        "assembly_unit_name": "1",
-                        "ncbi_assembly_unit_accession": "refseq:NC_000001.11"
-                    },
-                    {
-                        "assembly_unit_name": "2",
-                        "ncbi_assembly_unit_accession": "refseq:NC_000002.12"
-                    }
-                ]
-            }
-        },
-        "assay_files": [
-            {
-                "filename": "myfile1_NM305004_50000reads.cram.gpg",
-                "filetype": "CRAM",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "66526ffc57804187654eba000bc3905c",
-                "encrypted_checksum": "fdbfd70466017e8387bc55c65b553b2b"
-            },
-            {
-                "filename": "myfile2_NM305004_50000reads.cram.gpg",
-                "filetype": "CRAM",
-                "checksum_method": "MD5",
-                "unencrypted_checksum": "dc2f2f3aa81f299944e23aacf5a40b2c",
-                "encrypted_checksum": "db75a499836cd430cc9d25b5f89ea4c3"
-            }
-        ],
-        "assay_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAX00002094401"
-                    },
-                    "object_type": "experiment"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAZ00002024153"
-                    },
-                    "object_type": "analysis"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],    
-        "assay_attributes": [
+        "assayAttributes": [
             {
                 "tag": "weather",
                 "value": "When the assay was executed it was raining outside"
             },
             {
                 "tag": "assay price",
-                "value": 350,
-                "units": "euros"
+                "units": "euros",
+                "value": 350
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "assay",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        ],
+        "assayCenter": "EBI-TEST",
+        "assayDate": "2022-02-13",
+        "assayFiles": [
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "fdbfd70466017e8387bc55c65b553b2b",
+                "filename": "myfile1_NM305004_50000reads.cram.gpg",
+                "filetype": "CRAM",
+                "unencryptedChecksum": "66526ffc57804187654eba000bc3905c"
+            },
+            {
+                "checksumMethod": "MD5",
+                "encryptedChecksum": "db75a499836cd430cc9d25b5f89ea4c3",
+                "filename": "myfile2_NM305004_50000reads.cram.gpg",
+                "filetype": "CRAM",
+                "unencryptedChecksum": "dc2f2f3aa81f299944e23aacf5a40b2c"
+            }
+        ],
+        "assayRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAX00002094401"
+                    },
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAZ00002024153"
+                    },
+                    "objectType": "analysis"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "assayTypeSpecifications": {
+            "assayType": "sequencing",
+            "sequencingAssaySpecifications": {
+                "referenceAlignmentDetails": [
+                    {
+                        "assemblyName": "GRCh38.p14",
+                        "assemblyUnitName": "1",
+                        "ncbiAssemblyAccession": "assembly:GCF_000001405.26",
+                        "ncbiAssemblyUnitAccession": "refseq:NC_000001.11"
+                    },
+                    {
+                        "assemblyUnitName": "2",
+                        "ncbiAssemblyUnitAccession": "refseq:NC_000002.12"
+                    }
+                ]
+            }
+        },
+        "objectId": {
+            "alias": "My_sequencing_assay_M305004",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "Breast cancer sequencing assay M305004",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "assay"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.assay.json"
     }
 }

--- a/examples/json_validation_tests/dataset_valid-1.json
+++ b/examples/json_validation_tests/dataset_valid-1.json
@@ -1,64 +1,64 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.dataset.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "my-cancer-dataset_231", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "EBI test case-control dataset for cancer",
-        "object_description": "EBI genome-wide case-control association dataset for Hypertension (HT) using seven disease collections together with the 1958 Spanish Birth Cohort and the EU National Blood Service collections as controls.",
-        "dataset_type": "phenotype information",
-        "dataset_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {                
-                    "object_id": {
-                        "ega_accession": "EGAR00002043412"
-                    },
-                    "object_type": "assay"                                    
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {                
-                    "object_id": {
-                        "ega_accession": "EGAR00004343122"
-                    },
-                    "object_type": "assay"                                    
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {                
-                    "object_id": {
-                        "ega_accession": "EGAZ00004343122"
-                    },
-                    "object_type": "analysis"                                    
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "dataset_attributes": [
+        "datasetAttributes": [
             {
                 "tag": "Associated project ID",
-                "value": "X33981-DGH"            
+                "value": "X33981-DGH"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "dataset",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.dataset.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "datasetRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAR00002043412"
+                    },
+                    "objectType": "assay"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAR00004343122"
+                    },
+                    "objectType": "assay"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAZ00004343122"
+                    },
+                    "objectType": "analysis"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "datasetType": "phenotype information",
+        "objectDescription": "EBI genome-wide case-control association dataset for Hypertension (HT) using seven disease collections together with the 1958 Spanish Birth Cohort and the EU National Blood Service collections as controls.",
+        "objectId": {
+            "alias": "my-cancer-dataset_231",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "EBI test case-control dataset for cancer",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.dataset.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "dataset"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.dataset.json"
     }
 }

--- a/examples/json_validation_tests/dataset_valid-1.json
+++ b/examples/json_validation_tests/dataset_valid-1.json
@@ -14,7 +14,7 @@
                     },
                     "objectType": "assay"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -23,7 +23,7 @@
                     },
                     "objectType": "assay"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -32,7 +32,7 @@
                     },
                     "objectType": "analysis"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -41,7 +41,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "datasetType": "phenotype information",

--- a/examples/json_validation_tests/experiment_valid-1.json
+++ b/examples/json_validation_tests/experiment_valid-1.json
@@ -1,197 +1,197 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.experiment.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "My_ChIP_array_experiment_13", 
-            "center_name" : "EBI-TEST"
+        "assayTechnology": {
+            "assayInstrument": "array",
+            "assayInstrumentPlatform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
         },
-        "object_title": "Example array experiment title",
-        "object_description": "Example array experiment's description of my experiment N13.",
-        "assayed_molecule_type": "DNA",
-        "types_of_output_data": [
-            "genomic data"
-        ],
-        "assay_technology": {
-            "assay_instrument": "array",
-            "assay_instrument_platform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
+        "assayTypeDescriptor": {
+            "assayType": "ChIP-chip by SNP array"
         },
-        "assay_type_descriptor": {
-            "assay_type": "ChIP-chip by SNP array"
-        },
-        "experiment_type_specifications": {
-            "array_experiment": {
-                "array_labels": [
-                    {
-                        "array_label_id": "Cy3 dye",
-                        "array_label_curie": "CHEBI:37987",
-                        "label_description": "This label was use to dye the control samples"
-                    },
-                    {
-                        "array_label_id": "Biotin",
-                        "array_label_curie": "CHEBI:15956"
-                    }
-                ],
-                "adf_files": [
-                    {
-                        "filename": "myADF-file.xlsx",
-                        "filetype": "XLSX",
-                        "checksum_method": "MD5",
-                        "unencrypted_checksum": "c6779ec2960296ed9a04f08d67f64423",
-                        "encrypted_checksum": "c6779ec2960296ed9a04f08d67f64423"
-                    }
-                ]
-            }
-        },
-        "targeted_loci": [
+        "assayedMoleculeType": "DNA",
+        "experimentAttributes": [
             {
-                "organism_descriptor": {
-                    "taxon_id_curie": "NCBITaxon:9606",
-                    "scientific_name": "homo sapiens"
-                },
-                "loci_descriptor": [
-                    {
-                        "gene_descriptor": {
-                            "gene_symbol": "TP53",
-                            "gene_id_curie": "HGNC:11998"
-                        },
-                        "locus_additional_description": "The locus of TP53 within the array corresponds to a variant version of the defined gene, only existing in patients with the pulmonary disease."
-                    },
-                    {
-                        "genomic_sequence_descriptor": { 
-                            "assembly_descriptor": {
-                                "assembly_name": "GRCh38.p14",
-                                "ncbi_assembly_accession": "assembly:GCA_000001405.29",
-                                "assembly_unit_name": "Chromosome 17",
-                                "ncbi_assembly_unit_accession": "refseq:NC_000017.11"
-                            },
-                            "sequence_coordinates": {
-                                "sequence_interval": {
-                                    "start": 7669450,
-                                    "end": 7669460
-                                }
-                            },
-                            "dna_sequence_strand": "forward",
-                            "nucleic_acid_sequence": "CTTGTTCAGTG"
-                        }
-                    },
-                    {
-                        "locus_external_reference": {
-                            "external_accession_curie": "nucleotide:T35715.1",
-                            "accession_label": "EST89992 Human Small intestine Homo sapiens cDNA 5' end"
-                        },
-                        "locus_additional_description": "Additional locus that was placed in the array for SNP scanning for the purpose of individuals identification as tags..."
-                    }
-                ]
-            }
-        ],
-        "experiment_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAS00002045411"
-                    },
-                    "object_type": "study"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAZ00001051423"
-                    },
-                    "object_type": "analysis"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031671",
-                        "alias": "Patient's blood collection protocol"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031672",
-                        "alias": "Extraction of the RNA"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031673",
-                        "alias": "Protocol to label extracted RNA"
-                    },
-                    "object_type": "protocol"
-                },
-                "r_label": "Differed from the general protocol by using parameters X and Y with values ..."
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031674",
-                        "alias": "Hibridization of the RNA to the array"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031675",
-                        "alias": "Scanning of the array"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00001031676",
-                        "alias": "Normalization of the data"
-                    },
-                    "object_type": "protocol"
-                }
-            },        
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "experiment_attributes": [
-            {            
                 "tag": "sub_project",
                 "value": "CB4-1UD"
             },
-            {            
+            {
                 "tag": "experiments_budget",
-                "value": 20500,
-                "units": "GBP"
+                "units": "GBP",
+                "value": 20500
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "experiment",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
-        }
+        ],
+        "experimentRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAS00002045411"
+                    },
+                    "objectType": "study"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAZ00001051423"
+                    },
+                    "objectType": "analysis"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Patient's blood collection protocol",
+                        "egaAccession": "EGAO00001031671"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Extraction of the RNA",
+                        "egaAccession": "EGAO00001031672"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
+                "rSource": {
+                    "objectId": {
+                        "alias": "Protocol to label extracted RNA",
+                        "egaAccession": "EGAO00001031673"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Hibridization of the RNA to the array",
+                        "egaAccession": "EGAO00001031674"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Scanning of the array",
+                        "egaAccession": "EGAO00001031675"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "Normalization of the data",
+                        "egaAccession": "EGAO00001031676"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "experimentTypeSpecifications": {
+            "arrayExperiment": {
+                "adfFiles": [
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "c6779ec2960296ed9a04f08d67f64423",
+                        "filename": "myADF-file.xlsx",
+                        "filetype": "XLSX",
+                        "unencryptedChecksum": "c6779ec2960296ed9a04f08d67f64423"
+                    }
+                ],
+                "arrayLabels": [
+                    {
+                        "arrayLabelCurie": "CHEBI:37987",
+                        "arrayLabelId": "Cy3 dye",
+                        "labelDescription": "This label was use to dye the control samples"
+                    },
+                    {
+                        "arrayLabelCurie": "CHEBI:15956",
+                        "arrayLabelId": "Biotin"
+                    }
+                ]
+            }
+        },
+        "objectDescription": "Example array experiment's description of my experiment N13.",
+        "objectId": {
+            "alias": "My_ChIP_array_experiment_13",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "Example array experiment title",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "experiment"
+        },
+        "targetedLoci": [
+            {
+                "lociDescriptor": [
+                    {
+                        "geneDescriptor": {
+                            "geneIdCurie": "HGNC:11998",
+                            "geneSymbol": "TP53"
+                        },
+                        "locusAdditionalDescription": "The locus of TP53 within the array corresponds to a variant version of the defined gene, only existing in patients with the pulmonary disease."
+                    },
+                    {
+                        "genomicSequenceDescriptor": {
+                            "assemblyDescriptor": {
+                                "assemblyName": "GRCh38.p14",
+                                "assemblyUnitName": "Chromosome 17",
+                                "ncbiAssemblyAccession": "assembly:GCA_000001405.29",
+                                "ncbiAssemblyUnitAccession": "refseq:NC_000017.11"
+                            },
+                            "dnaSequenceStrand": "forward",
+                            "nucleicAcidSequence": "CTTGTTCAGTG",
+                            "sequenceCoordinates": {
+                                "sequenceInterval": {
+                                    "end": 7669460,
+                                    "start": 7669450
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "locusAdditionalDescription": "Additional locus that was placed in the array for SNP scanning for the purpose of individuals identification as tags...",
+                        "locusExternalReference": {
+                            "accessionLabel": "EST89992 Human Small intestine Homo sapiens cDNA 5' end",
+                            "externalAccessionCurie": "nucleotide:T35715.1"
+                        }
+                    }
+                ],
+                "organismDescriptor": {
+                    "scientificName": "homo sapiens",
+                    "taxonIdCurie": "NCBITaxon:9606"
+                }
+            }
+        ],
+        "typesOfOutputData": [
+            "genomic data"
+        ]
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.experiment.json"
     }
 }

--- a/examples/json_validation_tests/experiment_valid-1.json
+++ b/examples/json_validation_tests/experiment_valid-1.json
@@ -27,7 +27,7 @@
                     },
                     "objectType": "study"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -36,7 +36,7 @@
                     },
                     "objectType": "analysis"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -46,7 +46,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -56,7 +56,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
@@ -67,7 +67,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -77,7 +77,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -87,7 +87,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -97,7 +97,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -106,7 +106,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "experimentTypeSpecifications": {
@@ -135,7 +135,7 @@
         },
         "objectDescription": "Example array experiment's description of my experiment N13.",
         "objectId": {
-            "alias": "My_ChIP_array_experiment_13",
+            "alias": "My_ChIP_arrayExperiment_13",
             "centerName": "EBI-TEST"
         },
         "objectTitle": "Example array experiment title",

--- a/examples/json_validation_tests/individual_valid-1.json
+++ b/examples/json_validation_tests/individual_valid-1.json
@@ -14,7 +14,7 @@
                     },
                     "objectType": "sample"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -23,7 +23,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "minimalPublicAttributes": {

--- a/examples/json_validation_tests/individual_valid-1.json
+++ b/examples/json_validation_tests/individual_valid-1.json
@@ -1,69 +1,69 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.individual.json"
-    },
-    "data": {   
-        "object_id": {
-            "alias" : "NM305004", 
-            "center_name" : "EBI-TEST",
-            "ega_accession": "EGAI00000000001"
-        },
-        "organism_descriptor": {
-            "taxon_id_curie": "NCBITaxon:9606",
-            "scientific_name": "homo sapiens",
-            "common_name": "human"
-        },
-        "minimal_public_attributes": {
-            "subject_id": "donor-NM305004",
-            "biological_sex": "male",
-            "phenotypes": [
-                {
-                    "phenotypic_abnormality_curie": "HP:0033403",
-                    "phenotypic_abnormality_label": "Testicular ischemia"
-                }
-            ],
-            "diseases": [
-                {
-                    "disease_curie": "EFO:0003101",
-                    "disease_label": "testicular seminoma"
-                },
-                {
-                    "disease_curie": "EFO:1000254",
-                    "disease_label": "fibroadenoma"
-                }
-            ]
-        },
-        "individual_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAN00000000001"
-                    },
-                    "object_type": "sample"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "individual_attributes": [
+    "data": {
+        "individualAttributes": [
             {
                 "tag": "haircolor",
                 "value": "red"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "individual",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.individual.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "individualRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAN00000000001"
+                    },
+                    "objectType": "sample"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "minimalPublicAttributes": {
+            "biologicalSex": "male",
+            "diseases": [
+                {
+                    "diseaseCurie": "EFO:0003101",
+                    "diseaseLabel": "testicular seminoma"
+                },
+                {
+                    "diseaseCurie": "EFO:1000254",
+                    "diseaseLabel": "fibroadenoma"
+                }
+            ],
+            "phenotypes": [
+                {
+                    "phenotypicAbnormalityCurie": "HP:0033403",
+                    "phenotypicAbnormalityLabel": "Testicular ischemia"
+                }
+            ],
+            "subjectId": "donor-NM305004"
+        },
+        "objectId": {
+            "alias": "NM305004",
+            "centerName": "EBI-TEST",
+            "egaAccession": "EGAI00000000001"
+        },
+        "organismDescriptor": {
+            "commonName": "human",
+            "scientificName": "homo sapiens",
+            "taxonIdCurie": "NCBITaxon:9606"
+        },
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.individual.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "individual"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.individual.json"
     }
 }

--- a/examples/json_validation_tests/object-set_valid-1.json
+++ b/examples/json_validation_tests/object-set_valid-1.json
@@ -1,377 +1,377 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.object-set.json"
-    },
     "data": {
-        "schema_descriptor": {
-            "object_type": "object-set",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.object-set.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
-        },
-        "object_array": [
+        "objectArray": [
             {
-                "object_id": {
-                    "alias" : "My_ChIP_array_experiment_13", 
-                    "center_name" : "EBI-TEST"
+                "assayTechnology": {
+                    "assayInstrument": "array",
+                    "assayInstrumentPlatform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
                 },
-                "object_title": "Example array experiment title",
-                "object_description": "Example array experiment's description of my experiment N13.",
-                "assayed_molecule_type": "DNA",
-                "types_of_output_data": [
-                    "genomic data"
-                ],
-                "assay_technology": {
-                    "assay_instrument": "array",
-                    "assay_instrument_platform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
+                "assayTypeDescriptor": {
+                    "assayType": "ChIP-chip by SNP array"
                 },
-                "assay_type_descriptor": {
-                    "assay_type": "ChIP-chip by SNP array"
-                },
-                "experiment_type_specifications": {
-                    "array_experiment": {
-                        "array_labels": [
-                            {
-                                "array_label_id": "Cy3 dye",
-                                "array_label_curie": "CHEBI:37987",
-                                "label_description": "This label was use to dye the control samples"
-                            },
-                            {
-                                "array_label_id": "Biotin",
-                                "array_label_curie": "CHEBI:15956"
-                            }
-                        ],
-                        "adf_files": [
-                            {
-                                "filename": "myADF-file.xlsx",
-                                "filetype": "XLSX",
-                                "checksum_method": "MD5",
-                                "unencrypted_checksum": "c6779ec2960296ed9a04f08d67f64423",
-                                "encrypted_checksum": "c6779ec2960296ed9a04f08d67f64423"
-                            }
-                        ]
-                    }
-                },
-                "targeted_loci": [
+                "assayedMoleculeType": "DNA",
+                "experimentAttributes": [
                     {
-                        "organism_descriptor": {
-                            "taxon_id_curie": "NCBITaxon:9606",
-                            "scientific_name": "homo sapiens"
-                        },
-                        "loci_descriptor": [
-                            {
-                                "gene_descriptor": {
-                                    "gene_symbol": "TP53",
-                                    "gene_id_curie": "HGNC:11998"
-                                },
-                                "locus_additional_description": "The locus of TP53 within the array corresponds to a variant version of the defined gene, only existing in patients with the pulmonary disease."
-                            },
-                            {
-                                "genomic_sequence_descriptor": { 
-                                    "assembly_descriptor": {
-                                        "assembly_name": "GRCh38.p14",
-                                        "ncbi_assembly_accession": "assembly:GCA_000001405.29",
-                                        "assembly_unit_name": "Chromosome 17",
-                                        "ncbi_assembly_unit_accession": "refseq:NC_000017.11"
-                                    },
-                                    "sequence_coordinates": {
-                                        "sequence_interval": {
-                                            "start": 7669450,
-                                            "end": 7669460
-                                        }
-                                    },
-                                    "dna_sequence_strand": "forward",
-                                    "nucleic_acid_sequence": "CTTGTTCAGTG"
-                                }
-                            },
-                            {
-                                "locus_external_reference": {
-                                    "external_accession_curie": "nucleotide:T35715.1",
-                                    "accession_label": "EST89992 Human Small intestine Homo sapiens cDNA 5' end"
-                                },
-                                "locus_additional_description": "Additional locus that was placed in the array for SNP scanning for the purpose of individuals identification as tags..."
-                            }
-                        ]
-                    }
-                ],
-                "experiment_relationships": [
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAS00002045411"
-                            },
-                            "object_type": "study"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_target": {
-                            "object_id": {
-                                "ega_accession": "EGAZ00001051423"
-                            },
-                            "object_type": "analysis"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031671",
-                                "alias": "Patient's blood collection protocol"
-                            },
-                            "object_type": "protocol"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031672",
-                                "alias": "Extraction of the RNA"
-                            },
-                            "object_type": "protocol"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031673",
-                                "alias": "Protocol to label extracted RNA"
-                            },
-                            "object_type": "protocol"
-                        },
-                        "r_label": "Differed from the general protocol by using parameters X and Y with values ..."
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031674",
-                                "alias": "Hibridization of the RNA to the array"
-                            },
-                            "object_type": "protocol"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031675",
-                                "alias": "Scanning of the array"
-                            },
-                            "object_type": "protocol"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAO00001031676",
-                                "alias": "Normalization of the data"
-                            },
-                            "object_type": "protocol"
-                        }
-                    },        
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAB00002045411"
-                            },
-                            "object_type": "submission"                
-                        }
-                    }
-                ],
-                "experiment_attributes": [
-                    {            
                         "tag": "sub_project",
                         "value": "CB4-1UD"
                     },
-                    {            
+                    {
                         "tag": "experiments_budget",
-                        "value": 20500,
-                        "units": "GBP"
+                        "units": "GBP",
+                        "value": 20500
                     }
-                ]
-            },
-            {
-                "object_id": {
-                    "alias" : "My_sequencing_assay_M305004", 
-                    "center_name" : "EBI-TEST"
-                },
-                "object_title": "Breast cancer sequencing assay M305004",
-                "assay_center": "EBI-TEST",
-                "assay_date": "2022-02-13",
-                "assay_type_specifications": {
-                    "assay_type": "sequencing",
-                    "sequencing_assay_specifications": {
-                        "reference_alignment_details": [
+                ],
+                "experimentRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAS00002045411"
+                            },
+                            "objectType": "study"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rTarget": {
+                            "objectId": {
+                                "egaAccession": "EGAZ00001051423"
+                            },
+                            "objectType": "analysis"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Patient's blood collection protocol",
+                                "egaAccession": "EGAO00001031671"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Extraction of the RNA",
+                                "egaAccession": "EGAO00001031672"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Protocol to label extracted RNA",
+                                "egaAccession": "EGAO00001031673"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Hibridization of the RNA to the array",
+                                "egaAccession": "EGAO00001031674"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Scanning of the array",
+                                "egaAccession": "EGAO00001031675"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Normalization of the data",
+                                "egaAccession": "EGAO00001031676"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00002045411"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referenced_by"
+                    }
+                ],
+                "experimentTypeSpecifications": {
+                    "arrayExperiment": {
+                        "adfFiles": [
                             {
-                                "assembly_name": "GRCh38.p14",
-                                "ncbi_assembly_accession": "assembly:GCF_000001405.26",
-                                "assembly_unit_name": "1",
-                                "ncbi_assembly_unit_accession": "refseq:NC_000001.11"
+                                "checksumMethod": "MD5",
+                                "encryptedChecksum": "c6779ec2960296ed9a04f08d67f64423",
+                                "filename": "myADF-file.xlsx",
+                                "filetype": "XLSX",
+                                "unencryptedChecksum": "c6779ec2960296ed9a04f08d67f64423"
+                            }
+                        ],
+                        "arrayLabels": [
+                            {
+                                "arrayLabelCurie": "CHEBI:37987",
+                                "arrayLabelId": "Cy3 dye",
+                                "labelDescription": "This label was use to dye the control samples"
                             },
                             {
-                                "assembly_unit_name": "2",
-                                "ncbi_assembly_unit_accession": "refseq:NC_000002.12"
+                                "arrayLabelCurie": "CHEBI:15956",
+                                "arrayLabelId": "Biotin"
                             }
                         ]
                     }
                 },
-                "assay_files": [
+                "objectDescription": "Example array experiment's description of my experiment N13.",
+                "objectId": {
+                    "alias": "My_ChIP_array_experiment_13",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Example array experiment title",
+                "targetedLoci": [
                     {
-                        "filename": "myfile1_NM305004_50000reads.cram.gpg",
-                        "filetype": "CRAM",
-                        "checksum_method": "MD5",
-                        "unencrypted_checksum": "66526ffc57804187654eba000bc3905c",
-                        "encrypted_checksum": "fdbfd70466017e8387bc55c65b553b2b"
-                    },
-                    {
-                        "filename": "myfile2_NM305004_50000reads.cram.gpg",
-                        "filetype": "CRAM",
-                        "checksum_method": "MD5",
-                        "unencrypted_checksum": "dc2f2f3aa81f299944e23aacf5a40b2c",
-                        "encrypted_checksum": "db75a499836cd430cc9d25b5f89ea4c3"
+                        "lociDescriptor": [
+                            {
+                                "geneDescriptor": {
+                                    "geneIdCurie": "HGNC:11998",
+                                    "geneSymbol": "TP53"
+                                },
+                                "locusAdditionalDescription": "The locus of TP53 within the array corresponds to a variant version of the defined gene, only existing in patients with the pulmonary disease."
+                            },
+                            {
+                                "genomicSequenceDescriptor": {
+                                    "assemblyDescriptor": {
+                                        "assemblyName": "GRCh38.p14",
+                                        "assemblyUnitName": "Chromosome 17",
+                                        "ncbiAssemblyAccession": "assembly:GCA_000001405.29",
+                                        "ncbiAssemblyUnitAccession": "refseq:NC_000017.11"
+                                    },
+                                    "dnaSequenceStrand": "forward",
+                                    "nucleicAcidSequence": "CTTGTTCAGTG",
+                                    "sequenceCoordinates": {
+                                        "sequenceInterval": {
+                                            "end": 7669460,
+                                            "start": 7669450
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "locusAdditionalDescription": "Additional locus that was placed in the array for SNP scanning for the purpose of individuals identification as tags...",
+                                "locusExternalReference": {
+                                    "accessionLabel": "EST89992 Human Small intestine Homo sapiens cDNA 5' end",
+                                    "externalAccessionCurie": "nucleotide:T35715.1"
+                                }
+                            }
+                        ],
+                        "organismDescriptor": {
+                            "scientificName": "homo sapiens",
+                            "taxonIdCurie": "NCBITaxon:9606"
+                        }
                     }
                 ],
-                "assay_relationships": [
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAX00002095401"
-                            },
-                            "object_type": "experiment"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAB00002045411"
-                            },
-                            "object_type": "submission"                
-                        }
-                    }
-                ],    
-                "assay_attributes": [
+                "typesOfOutputData": [
+                    "genomic data"
+                ]
+            },
+            {
+                "assayAttributes": [
                     {
                         "tag": "weather",
                         "value": "When the assay was executed it was raining outside"
                     },
                     {
                         "tag": "assay price",
-                        "value": 350,
-                        "units": "euros"
+                        "units": "euros",
+                        "value": 350
                     }
-                ],    
-                "schema_descriptor": {
-                    "object_type": "assay",
-                    "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
-                    "object_schema_version": "0.0.0",
-                    "common_schema_version": "0.0.0"
-                }
-            },
-            {
-                "object_id": {
-                    "alias" : "My_array_assay_M3051057", 
-                    "center_name" : "EBI-TEST"
-                },
-                "object_title": "Breast cancer array assay M3051057",
-                "assay_center": "EBI-TEST",
-                "assay_date": "2022-02-13",
-                "assay_type_specifications": {
-                    "assay_type": "array",
-                    "array_assay_specifications": {
-                        "n_labels_per_array": 2,
-                        "array_sample_labels": [
+                ],
+                "assayCenter": "EBI-TEST",
+                "assayDate": "2022-02-13",
+                "assayFiles": [
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "fdbfd70466017e8387bc55c65b553b2b",
+                        "filename": "myfile1_NM305004_50000reads.cram.gpg",
+                        "filetype": "CRAM",
+                        "unencryptedChecksum": "66526ffc57804187654eba000bc3905c"
+                    },
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "db75a499836cd430cc9d25b5f89ea4c3",
+                        "filename": "myfile2_NM305004_50000reads.cram.gpg",
+                        "filetype": "CRAM",
+                        "unencryptedChecksum": "dc2f2f3aa81f299944e23aacf5a40b2c"
+                    }
+                ],
+                "assayRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAX00002095401"
+                            },
+                            "objectType": "experiment"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00002045411"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referenced_by"
+                    }
+                ],
+                "assayTypeSpecifications": {
+                    "assayType": "sequencing",
+                    "sequencingAssaySpecifications": {
+                        "referenceAlignmentDetails": [
                             {
-                                "label": {
-                                    "array_label_id": "Cy3",
-                                    "array_label_curie": "CHEBI:37987"
-                                },
-                                "object_id": {
-                                    "ega_accession": "EGAN00002094401"
-                                }
+                                "assemblyName": "GRCh38.p14",
+                                "assemblyUnitName": "1",
+                                "ncbiAssemblyAccession": "assembly:GCF_000001405.26",
+                                "ncbiAssemblyUnitAccession": "refseq:NC_000001.11"
                             },
                             {
-                                "label": {
-                                    "array_label_id": "Cy5",
-                                    "array_label_curie": "CHEBI:37989"
-                                },
-                                "object_id": {
-                                    "ega_accession": "EGAN00002094453"
-                                }
+                                "assemblyUnitName": "2",
+                                "ncbiAssemblyUnitAccession": "refseq:NC_000002.12"
                             }
                         ]
                     }
                 },
-                "assay_files": [
-                    {
-                        "filename": "myfile1_M3051057.cel.gpg",
-                        "filetype": "CEL",
-                        "checksum_method": "MD5",
-                        "unencrypted_checksum": "9a4249e4b0538b9789c5d7f25d6342f0",
-                        "encrypted_checksum": "0beca40a04c283069df9c484ef7e2c68"
-                    },
-                    {
-                        "filename": "myfile2_M3051057.cel.gpg",
-                        "filetype": "CEL",
-                        "checksum_method": "MD5",
-                        "unencrypted_checksum": "7cfc795b42d428697ca8e33bf1fb8228",
-                        "encrypted_checksum": "d92463599ed4548cfa4fff55c1b48d7e"
-                    }
-                ],
-                "assay_relationships": [
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAX00002094401"
-                            },
-                            "object_type": "experiment"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAZ00002024153"
-                            },
-                            "object_type": "analysis"
-                        }
-                    },
-                    {
-                        "r_type": "referenced_by",
-                        "r_source": {
-                            "object_id": {
-                                "ega_accession": "EGAB00002045411"
-                            },
-                            "object_type": "submission"                
-                        }
-                    }
-                ],    
-                "assay_attributes": [
+                "objectId": {
+                    "alias": "My_sequencing_assay_M305004",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Breast cancer sequencing assay M305004",
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "assay"
+                }
+            },
+            {
+                "assayAttributes": [
                     {
                         "tag": "weather",
                         "value": "When the assay was executed it was rainy outside"
                     },
                     {
                         "tag": "assay price",
-                        "value": 200,
-                        "units": "euros"
+                        "units": "euros",
+                        "value": 200
                     }
-                ],    
-                "schema_descriptor": {
-                    "object_type": "assay",
-                    "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
-                    "object_schema_version": "0.0.0",
-                    "common_schema_version": "0.0.0"
+                ],
+                "assayCenter": "EBI-TEST",
+                "assayDate": "2022-02-13",
+                "assayFiles": [
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "0beca40a04c283069df9c484ef7e2c68",
+                        "filename": "myfile1_M3051057.cel.gpg",
+                        "filetype": "CEL",
+                        "unencryptedChecksum": "9a4249e4b0538b9789c5d7f25d6342f0"
+                    },
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "d92463599ed4548cfa4fff55c1b48d7e",
+                        "filename": "myfile2_M3051057.cel.gpg",
+                        "filetype": "CEL",
+                        "unencryptedChecksum": "7cfc795b42d428697ca8e33bf1fb8228"
+                    }
+                ],
+                "assayRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAX00002094401"
+                            },
+                            "objectType": "experiment"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAZ00002024153"
+                            },
+                            "objectType": "analysis"
+                        },
+                        "rType": "referenced_by"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00002045411"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referenced_by"
+                    }
+                ],
+                "assayTypeSpecifications": {
+                    "arrayAssaySpecifications": {
+                        "arraySampleLabels": [
+                            {
+                                "label": {
+                                    "arrayLabelCurie": "CHEBI:37987",
+                                    "arrayLabelId": "Cy3"
+                                },
+                                "objectId": {
+                                    "egaAccession": "EGAN00002094401"
+                                }
+                            },
+                            {
+                                "label": {
+                                    "arrayLabelCurie": "CHEBI:37989",
+                                    "arrayLabelId": "Cy5"
+                                },
+                                "objectId": {
+                                    "egaAccession": "EGAN00002094453"
+                                }
+                            }
+                        ],
+                        "nLabelsPerArray": 2
+                    },
+                    "assayType": "array"
+                },
+                "objectId": {
+                    "alias": "My_array_assay_M3051057",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Breast cancer array assay M3051057",
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "assay"
                 }
-            }        
-        ]
+            }
+        ],
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.object-set.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "object-set"
+        }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.object-set.json"
     }
 }

--- a/examples/json_validation_tests/object-set_valid-1.json
+++ b/examples/json_validation_tests/object-set_valid-1.json
@@ -29,7 +29,7 @@
                             },
                             "objectType": "study"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rTarget": {
@@ -38,7 +38,7 @@
                             },
                             "objectType": "analysis"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -48,7 +48,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -58,7 +58,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rLabel": "Differed from the general protocol by using parameters X and Y with values ...",
@@ -69,7 +69,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -79,7 +79,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -89,7 +89,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -99,7 +99,7 @@
                             },
                             "objectType": "protocol"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -108,7 +108,7 @@
                             },
                             "objectType": "submission"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     }
                 ],
                 "experimentTypeSpecifications": {
@@ -137,7 +137,7 @@
                 },
                 "objectDescription": "Example array experiment's description of my experiment N13.",
                 "objectId": {
-                    "alias": "My_ChIP_array_experiment_13",
+                    "alias": "My_ChIP_arrayExperiment_13",
                     "centerName": "EBI-TEST"
                 },
                 "objectTitle": "Example array experiment title",
@@ -225,7 +225,7 @@
                             },
                             "objectType": "experiment"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -234,7 +234,7 @@
                             },
                             "objectType": "submission"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     }
                 ],
                 "assayTypeSpecifications": {
@@ -304,7 +304,7 @@
                             },
                             "objectType": "experiment"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -313,7 +313,7 @@
                             },
                             "objectType": "analysis"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     },
                     {
                         "rSource": {
@@ -322,7 +322,7 @@
                             },
                             "objectType": "submission"
                         },
-                        "rType": "referenced_by"
+                        "rType": "referencedBy"
                     }
                 ],
                 "assayTypeSpecifications": {

--- a/examples/json_validation_tests/policy_valid-1.json
+++ b/examples/json_validation_tests/policy_valid-1.json
@@ -28,7 +28,7 @@
                     },
                     "objectType": "dataset"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -37,7 +37,7 @@
                     },
                     "objectType": "dataset"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -46,7 +46,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "schemaDescriptor": {

--- a/examples/json_validation_tests/policy_valid-1.json
+++ b/examples/json_validation_tests/policy_valid-1.json
@@ -1,58 +1,62 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.policy.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "my-cancer-policy", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "EBI test case-control policy for cancer datasets",
-        "policy_descriptor": {
-            "policy_reference": "https://ega-archive.org/submission/dac/documentation",
-            "policy_text": "The data is fully available upon request with the data-access committee of this study."
-        },
-        "duo_codes_curies": [ "DUO:0000046", "DUO:0000028", "IAO:0000620" ],
-        "policy_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAD00002043982"
-                    },
-                    "object_type": "dataset"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAD00004543981"
-                    },
-                    "object_type": "dataset"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
+        "duoCodesCuries": [
+            "DUO:0000046",
+            "DUO:0000028",
+            "IAO:0000620"
         ],
-        "policy_attributes": [
+        "objectId": {
+            "alias": "my-cancer-policy",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "EBI test case-control policy for cancer datasets",
+        "policyAttributes": [
             {
                 "tag": "Associated project ID",
-                "value": "X33981-DGH"            
+                "value": "X33981-DGH"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "policy",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.policy.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "policyDescriptor": {
+            "policyReference": "https://ega-archive.org/submission/dac/documentation",
+            "policyText": "The data is fully available upon request with the data-access committee of this study."
+        },
+        "policyRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAD00002043982"
+                    },
+                    "objectType": "dataset"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAD00004543981"
+                    },
+                    "objectType": "dataset"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.policy.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "policy"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.policy.json"
     }
 }

--- a/examples/json_validation_tests/protocol_valid-1.json
+++ b/examples/json_validation_tests/protocol_valid-1.json
@@ -32,7 +32,7 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -41,17 +41,17 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
                     "objectId": {
-                        "alias": "sample_collection_protocol",
+                        "alias": "sampleCollection_protocol",
                         "centerName": "EBI-TEST"
                     },
                     "objectType": "protocol"
                 },
-                "rType": "is_after"
+                "rType": "isAfter"
             },
             {
                 "rSource": {
@@ -60,7 +60,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "protocolTypeDescriptor": {

--- a/examples/json_validation_tests/protocol_valid-1.json
+++ b/examples/json_validation_tests/protocol_valid-1.json
@@ -1,76 +1,81 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "RNA_hybridization_protocol", 
-            "center_name" : "EBI-TEST"
+        "objectId": {
+            "alias": "RNA_hybridization_protocol",
+            "centerName": "EBI-TEST"
         },
-        "object_title": "Hibridization of the RNA to the array",
-        "protocol_type_descriptor": {
-            "protocol_type": "hybridization",
-            "protocol_subtype": "Nucleic acid hybridization to array",
-            "protocol_subtype_curie": "EFO:0003815"
-        },
-        "protocol_performers": [ "EGA's Lab Technician group", "Technician N41394" ],
-        "protocol_instruments": [ "Human Genome U133 Plus 2.0 tiling array [OBI:0002023]" ],
-        "protocol_description": "Affymetrix Human GeneChip U133 Plus 2.0 Array was used for RNA hybridization according to the manufacturer's protocol (Affymetrix).",
-        "protocol_relationships": [
+        "objectTitle": "Hibridization of the RNA to the array",
+        "protocolAttributes": [
             {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAX00002045411"
-                    },
-                    "object_type": "experiment"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAX00002045412"
-                    },
-                    "object_type": "experiment"
-                }
-            },
-            {
-                "r_type": "is_after",
-                "r_target": {
-                    "object_id": {
-                        "alias" : "sample_collection_protocol", 
-                        "center_name" : "EBI-TEST"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "protocol_attributes": [
-            {            
                 "tag": "step_index",
                 "value": "2"
             },
-            {            
+            {
                 "tag": "instrument_cost",
-                "value": 2500,
-                "units": "GBP"
+                "units": "GBP",
+                "value": 2500
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "protocol",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        ],
+        "protocolDescription": "Affymetrix Human GeneChip U133 Plus 2.0 Array was used for RNA hybridization according to the manufacturer's protocol (Affymetrix).",
+        "protocolInstruments": [
+            "Human Genome U133 Plus 2.0 tiling array [OBI:0002023]"
+        ],
+        "protocolPerformers": [
+            "EGA's Lab Technician group",
+            "Technician N41394"
+        ],
+        "protocolRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAX00002045411"
+                    },
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAX00002045412"
+                    },
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rTarget": {
+                    "objectId": {
+                        "alias": "sample_collection_protocol",
+                        "centerName": "EBI-TEST"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "is_after"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "protocolTypeDescriptor": {
+            "protocolSubtype": "Nucleic acid hybridization to array",
+            "protocolSubtypeCurie": "EFO:0003815",
+            "protocolType": "hybridization"
+        },
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "protocol"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
     }
 }

--- a/examples/json_validation_tests/protocol_valid-2.json
+++ b/examples/json_validation_tests/protocol_valid-2.json
@@ -1,66 +1,71 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "sample_collection_protocol", 
-            "center_name" : "EBI-TEST"
+        "objectId": {
+            "alias": "sample_collection_protocol",
+            "centerName": "EBI-TEST"
         },
-        "object_title": "Patient's blood collection protocol",
-        "protocol_type_descriptor": {
-            "protocol_type": "sample collection",
-            "protocol_subtype_curie": "EFO:0005518"
-        },
-        "protocol_performers": [ "Addenbrooke's Hospital nurse" ],
-        "protocol_instruments": [ "Syringe [OBI:0000422]", "PAXgene Blood DNA Tube [NCIT:C126393]" ],
-        "protocol_description": "Total PBMC were collected from blood of HIV-1 patients. H1N1, H3N2, and B mean the influenza virus subtypes (influenza virus H1N1, influenza virus H3N2, and influenza virus B subtypes). HIV+ subjects were stratified as immune responders and immune non-responders post-vaccination (“responders”≥ 4-fold increase of neutralization antibody at Day28/Day0; “non-responders” < 4-fold increase of neutralization antibody at Day28/Day0) to each influenza subtypes. RNA was isolated from the fresh isolated PBMCs on Day0 and Day7 in each responder and non-responder. So, the 0w means at day 0, 1w means at day 7.",
-        "protocol_relationships": [
+        "objectTitle": "Patient's blood collection protocol",
+        "protocolAttributes": [
             {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAN00002045411"
-                    },
-                    "object_type": "sample"
-                }
-            },
-            {
-                "r_type": "is_after",
-                "r_source": {
-                    "object_id": {
-                        "alias" : "RNA_hybridization_protocol", 
-                        "center_name" : "EBI-TEST"
-                    },
-                    "object_type": "protocol"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
-            }
-        ],
-        "protocol_attributes": [
-            {            
                 "tag": "step_index",
                 "value": "1"
             },
-            {            
+            {
                 "tag": "instrument_cost",
-                "value": 15,
-                "units": "GBP"
+                "units": "GBP",
+                "value": 15
             }
-        ],    
-        "schema_descriptor": {
-            "object_type": "protocol",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        ],
+        "protocolDescription": "Total PBMC were collected from blood of HIV-1 patients. H1N1, H3N2, and B mean the influenza virus subtypes (influenza virus H1N1, influenza virus H3N2, and influenza virus B subtypes). HIV+ subjects were stratified as immune responders and immune non-responders post-vaccination (\u201cresponders\u201d\u2265 4-fold increase of neutralization antibody at Day28/Day0; \u201cnon-responders\u201d < 4-fold increase of neutralization antibody at Day28/Day0) to each influenza subtypes. RNA was isolated from the fresh isolated PBMCs on Day0 and Day7 in each responder and non-responder. So, the 0w means at day 0, 1w means at day 7.",
+        "protocolInstruments": [
+            "Syringe [OBI:0000422]",
+            "PAXgene Blood DNA Tube [NCIT:C126393]"
+        ],
+        "protocolPerformers": [
+            "Addenbrooke's Hospital nurse"
+        ],
+        "protocolRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAN00002045411"
+                    },
+                    "objectType": "sample"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "alias": "RNA_hybridization_protocol",
+                        "centerName": "EBI-TEST"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "is_after"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "protocolTypeDescriptor": {
+            "protocolSubtypeCurie": "EFO:0005518",
+            "protocolType": "sample collection"
+        },
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "protocol"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
     }
 }

--- a/examples/json_validation_tests/protocol_valid-2.json
+++ b/examples/json_validation_tests/protocol_valid-2.json
@@ -1,7 +1,7 @@
 {
     "data": {
         "objectId": {
-            "alias": "sample_collection_protocol",
+            "alias": "sampleCollection_protocol",
             "centerName": "EBI-TEST"
         },
         "objectTitle": "Patient's blood collection protocol",
@@ -32,7 +32,7 @@
                     },
                     "objectType": "sample"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -42,7 +42,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "is_after"
+                "rType": "isAfter"
             },
             {
                 "rSource": {
@@ -51,7 +51,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "protocolTypeDescriptor": {

--- a/examples/json_validation_tests/protocol_valid-3.json
+++ b/examples/json_validation_tests/protocol_valid-3.json
@@ -17,7 +17,7 @@
                     },
                     "objectType": "analysis"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -26,7 +26,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "protocolSoftware": [

--- a/examples/json_validation_tests/protocol_valid-3.json
+++ b/examples/json_validation_tests/protocol_valid-3.json
@@ -1,46 +1,51 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "genome_indexing_Prot23", 
-            "center_name" : "EBI-TEST"
+        "objectId": {
+            "alias": "genome_indexing_Prot23",
+            "centerName": "EBI-TEST"
         },
-        "object_title": "Genome indexing protocol",
-        "protocol_type_descriptor": {
-            "protocol_type": "data transformation",
-            "protocol_subtype": "genome indexing",
-            "protocol_subtype_curie": "operation:3211"
-        },
-        "protocol_performers": [ "EGA's testing bioinformaticians"],
-        "protocol_software": [ "FastQC v1.1.0 [SWO:1100144]", "SAMtools [SWO:1100143]" ],
-        "protocol_description": "Index the reads in the run. You can use as input a FASTA file (preferred) or a FASTQ. The file can also be compressed with gzip, having a .gz extension. The script will uncompress the file and pass it to FASTA format if it's a FASTQ file. Run ``./index.sh your_run_id /mnt/c/your_run.fastq.gz``.",
-        "protocol_relationships": [
+        "objectTitle": "Genome indexing protocol",
+        "protocolDescription": "Index the reads in the run. You can use as input a FASTA file (preferred) or a FASTQ. The file can also be compressed with gzip, having a .gz extension. The script will uncompress the file and pass it to FASTA format if it's a FASTQ file. Run ``./index.sh your_run_id /mnt/c/your_run.fastq.gz``.",
+        "protocolPerformers": [
+            "EGA's testing bioinformaticians"
+        ],
+        "protocolRelationships": [
             {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAZ00002045411"
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAZ00002045411"
                     },
-                    "object_type": "analysis"
-                }
+                    "objectType": "analysis"
+                },
+                "rType": "referenced_by"
             },
             {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
                     },
-                    "object_type": "submission"                
-                }
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "protocol",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "protocolSoftware": [
+            "FastQC v1.1.0 [SWO:1100144]",
+            "SAMtools [SWO:1100143]"
+        ],
+        "protocolTypeDescriptor": {
+            "protocolSubtype": "genome indexing",
+            "protocolSubtypeCurie": "operation:3211",
+            "protocolType": "data transformation"
+        },
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.protocol.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "protocol"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.protocol.json"
     }
 }

--- a/examples/json_validation_tests/sample_valid-1.json
+++ b/examples/json_validation_tests/sample_valid-1.json
@@ -1,113 +1,115 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.sample.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "My_sample_X_from_NM305004", 
-            "center_name" : "EBI-TEST",
-            "ega_accession": "EGAN00000000001"
-        },
-        "object_title": "Skin biopsy from COVID+ patient NM305004",
-        "object_description": "Skin biopsy from COVID positive patient (NM305004) that travelled back from Alaska.",
-        "organism_descriptor": {
-            "taxon_id_curie": "NCBITaxon:9606",
-            "scientific_name": "homo sapiens",
-            "common_name": "human"
-        },
-        "sample_types": [ "tissue culture" ],
-        "cell_types": [ 
+        "cellTypes": [
             {
-                "cell_type_id": "CL:0000066",
-                "cell_type_label": "epithelial cell",
-                "inferred_cell_type": "not inferred"
+                "cellTypeId": "CL:0000066",
+                "cellTypeLabel": "epithelial cell",
+                "inferredCellType": "not inferred"
             },
             {
-                "cell_type_id": "CL:0000097",
-                "cell_type_label": "mast cell",
-                "inferred_cell_type": "not inferred"
-            }
-         ],
-         "sample_status": [
-            {
-                "case_vs_control": "case",
-                "condition_under_study": {
-                    "cus_curie": "XCO:0000398",
-                    "cus_label": "treated with cisplatin"
-                }
-            }
-         ],
-        "sample_collection": {
-            "sample_collection_date": "2021-12-20",
-            "age_at_collection": {
-                "age_range": {
-                    "start": "P5Y",
-                    "end": "P10Y"
-                }
-            },
-            "sampling_site": {
-                "sampled_organism_part": "axilla skin",
-                "sampled_organism_part_curie": "UBERON:0015474"
-            }
-        },
-        "sample_grouping": {
-            "sample_group_boolean": false
-        },
-        "sample_relationships": [
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAI00002045411"
-                    },
-                    "object_type": "individual"                
-                }
-            },
-            {
-                "r_type": "same_as",
-                "r_source": {
-                    "object_id": {
-                        "external_accessions": [
-                            {
-                                "external_accession_curie": "biosample:SAMEA7616999",
-                                "accession_label": "test relationship"
-                            }
-                        ]
-                    },
-                    "object_type": "external_accession"
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAO00002045411"
-                    },
-                    "object_type": "protocol"                
-                }
-            },
-            {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
-                    },
-                    "object_type": "submission"                
-                }
+                "cellTypeId": "CL:0000097",
+                "cellTypeLabel": "mast cell",
+                "inferredCellType": "not inferred"
             }
         ],
-        "sample_attributes": [
+        "objectDescription": "Skin biopsy from COVID positive patient (NM305004) that travelled back from Alaska.",
+        "objectId": {
+            "alias": "My_sample_X_from_NM305004",
+            "centerName": "EBI-TEST",
+            "egaAccession": "EGAN00000000001"
+        },
+        "objectTitle": "Skin biopsy from COVID+ patient NM305004",
+        "organismDescriptor": {
+            "commonName": "human",
+            "scientificName": "homo sapiens",
+            "taxonIdCurie": "NCBITaxon:9606"
+        },
+        "sampleAttributes": [
             {
-                "units": "ml",
                 "tag": "biopsy volume",
+                "units": "ml",
                 "value": "30"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "sample",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
+        "sampleCollection": {
+            "ageAtCollection": {
+                "ageRange": {
+                    "end": "P10Y",
+                    "start": "P5Y"
+                }
+            },
+            "sampleCollectionDate": "2021-12-20",
+            "samplingSite": {
+                "sampledOrganismPart": "axilla skin",
+                "sampledOrganismPartCurie": "UBERON:0015474"
+            }
+        },
+        "sampleGrouping": {
+            "sampleGroupBoolean": false
+        },
+        "sampleRelationships": [
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAI00002045411"
+                    },
+                    "objectType": "individual"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "externalAccessions": [
+                            {
+                                "accessionLabel": "test relationship",
+                                "externalAccessionCurie": "biosample:SAMEA7616999"
+                            }
+                        ]
+                    },
+                    "objectType": "external_accession"
+                },
+                "rType": "same_as"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAO00002045411"
+                    },
+                    "objectType": "protocol"
+                },
+                "rType": "referenced_by"
+            },
+            {
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
+            }
+        ],
+        "sampleStatus": [
+            {
+                "caseVsControl": "case",
+                "conditionUnderStudy": {
+                    "cusCurie": "XCO:0000398",
+                    "cusLabel": "treated with cisplatin"
+                }
+            }
+        ],
+        "sampleTypes": [
+            "tissue culture"
+        ],
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "sample"
         }
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.sample.json"
     }
 }

--- a/examples/json_validation_tests/sample_valid-1.json
+++ b/examples/json_validation_tests/sample_valid-1.json
@@ -55,7 +55,7 @@
                     },
                     "objectType": "individual"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -67,9 +67,9 @@
                             }
                         ]
                     },
-                    "objectType": "external_accession"
+                    "objectType": "externalAccession"
                 },
-                "rType": "same_as"
+                "rType": "sameAs"
             },
             {
                 "rSource": {
@@ -78,7 +78,7 @@
                     },
                     "objectType": "protocol"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rSource": {
@@ -87,7 +87,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "sampleStatus": [

--- a/examples/json_validation_tests/study_valid-1.json
+++ b/examples/json_validation_tests/study_valid-1.json
@@ -1,66 +1,66 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.study.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "my-covid19-study_231", 
-            "center_name" : "EBI-TEST"
+        "objectDescription": "EBI genome-wide case-control association study for COVID-19 using seven disease collections together with the 1958 Spanish Birth Cohort and the EU National Blood Service collections as controls.",
+        "objectId": {
+            "alias": "my-covid19-study_231",
+            "centerName": "EBI-TEST"
         },
-        "object_title": "EBI test case-control study for covid19",
-        "object_description": "EBI genome-wide case-control association study for COVID-19 using seven disease collections together with the 1958 Spanish Birth Cohort and the EU National Blood Service collections as controls.",
-        "study_types": [ 
-            "COVID-19"
+        "objectTitle": "EBI test case-control study for covid19",
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.study.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "study"
+        },
+        "studyAttributes": [
+            {
+                "tag": "Associated project ID",
+                "value": "X33981-DGH"
+            }
         ],
-        "study_designs": [
+        "studyDesigns": [
             "case control design",
             "binding site identification design"
         ],
-        "study_relationships": [
+        "studyRelationships": [
             {
-                "r_type": "referenced_by",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAX00002043412"
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAX00002043412"
                     },
-                    "object_type": "experiment"                             
-                }
+                    "objectType": "experiment"
+                },
+                "rType": "referenced_by"
             },
             {
-                "r_type": "same_as",
-                "r_target": {
-                    "object_id": {
-                        "external_accessions": [
+                "rTarget": {
+                    "objectId": {
+                        "externalAccessions": [
                             {
-                                "external_accession_curie": "biostudies:S-EPMC3314381",
-                                "accession_label": "The same study was submitted to the two archives due to a deadline approaching."
+                                "accessionLabel": "The same study was submitted to the two archives due to a deadline approaching.",
+                                "externalAccessionCurie": "biostudies:S-EPMC3314381"
                             }
                         ]
                     },
-                    "object_type": "external_accession"                                                             
-                }
+                    "objectType": "external_accession"
+                },
+                "rType": "same_as"
             },
             {
-                "r_type": "referenced_by",
-                "r_source": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002045411"
+                "rSource": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002045411"
                     },
-                    "object_type": "submission"                
-                }
+                    "objectType": "submission"
+                },
+                "rType": "referenced_by"
             }
         ],
-        "study_attributes": [
-            {
-                "tag": "Associated project ID",
-                "value": "X33981-DGH"            
-            }
-        ],
-        "schema_descriptor": {
-            "object_type": "study",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.study.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
-        }
+        "studyTypes": [
+            "COVID-19"
+        ]
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.study.json"
     }
 }

--- a/examples/json_validation_tests/study_valid-1.json
+++ b/examples/json_validation_tests/study_valid-1.json
@@ -30,7 +30,7 @@
                     },
                     "objectType": "experiment"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             },
             {
                 "rTarget": {
@@ -42,9 +42,9 @@
                             }
                         ]
                     },
-                    "objectType": "external_accession"
+                    "objectType": "externalAccession"
                 },
-                "rType": "same_as"
+                "rType": "sameAs"
             },
             {
                 "rSource": {
@@ -53,7 +53,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "referenced_by"
+                "rType": "referencedBy"
             }
         ],
         "studyTypes": [

--- a/examples/json_validation_tests/submission_valid-1.json
+++ b/examples/json_validation_tests/submission_valid-1.json
@@ -57,7 +57,7 @@
                     },
                     "objectType": "submission"
                 },
-                "rType": "is_after"
+                "rType": "isAfter"
             }
         ]
     },

--- a/examples/json_validation_tests/submission_valid-1.json
+++ b/examples/json_validation_tests/submission_valid-1.json
@@ -1,67 +1,67 @@
 {
-    "schema": {
-        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.submission.json"
-    },
     "data": {
-        "object_id": {
-            "alias" : "submission_XF40", 
-            "center_name" : "EBI-TEST"
-        },
-        "object_title": "Submission XF40",
-        "object_description": "EBI submission project XF40 of 1000 samples and its 1500 sequencing runs",
-        "additional_collaborators": [
+        "additionalCollaborators": [
             {
-                "collaborator_rights": "read_and_write",
-                "collaborator_contact_details": {
-                    "institution_name": "EMBL European Bioinformatics Institute (EBI)",
-                    "email_address": "example@gmail.com"
-                }
+                "collaboratorContactDetails": {
+                    "emailAddress": "example@gmail.com",
+                    "institutionName": "EMBL European Bioinformatics Institute (EBI)"
+                },
+                "collaboratorRights": "read_and_write"
             },
             {
-                "collaborator_rights": "read_only",
-                "collaborator_contact_details": {
-                    "individual_full_name": "Isaac Asimov",
-                    "institution_name": "Boston University",
-                    "email_address": "example@ebi.ac.uk"
-                }
+                "collaboratorContactDetails": {
+                    "emailAddress": "example@ebi.ac.uk",
+                    "individualFullName": "Isaac Asimov",
+                    "institutionName": "Boston University"
+                },
+                "collaboratorRights": "read_only"
             }
         ],
+        "objectDescription": "EBI submission project XF40 of 1000 samples and its 1500 sequencing runs",
+        "objectId": {
+            "alias": "submission_XF40",
+            "centerName": "EBI-TEST"
+        },
+        "objectTitle": "Submission XF40",
         "resources": [
             {
+                "automaticallyAssigned": false,
                 "name": "Human Phenotype Ontology",
-                "namespace_prefix": "HP",
-                "version": "2022-06-11",
-                "automatically_assigned": false
+                "namespacePrefix": "HP",
+                "version": "2022-06-11"
             },
             {
+                "automaticallyAssigned": false,
                 "name": "Experimental Factor Ontology",
-                "namespace_prefix": "EFO",
-                "version": "3.45.0",
-                "automatically_assigned": false
+                "namespacePrefix": "EFO",
+                "version": "3.45.0"
             }
         ],
-        "submission_relationships": [
-            {
-                "r_type": "is_after",
-                "r_target": {
-                    "object_id": {
-                        "ega_accession": "EGAB00002543432"
-                    },
-                    "object_type": "submission"                             
-                }
-            }
-        ],
-        "submission_attributes": [
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.submission.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "submission"
+        },
+        "submissionAttributes": [
             {
                 "tag": "internal submission identifier",
-                "value": "XF40"            
+                "value": "XF40"
             }
         ],
-        "schema_descriptor": {
-            "object_type": "submission",
-            "described_by_schema_uri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.submission.json",
-            "object_schema_version": "0.0.0",
-            "common_schema_version": "0.0.0"
-        }
+        "submissionRelationships": [
+            {
+                "rTarget": {
+                    "objectId": {
+                        "egaAccession": "EGAB00002543432"
+                    },
+                    "objectType": "submission"
+                },
+                "rType": "is_after"
+            }
+        ]
+    },
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.submission.json"
     }
 }

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -6,36 +6,36 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Data Access Committee (DAC) metadata object. This object is intended to contain metadata about the body of one or more named individuals who are responsible for data release to external requestors based on consent and/or National Research Ethics terms. A DAC is typically formed, but not necessarily, from the same organization that collected the samples and generated any associated files/analyses. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/data_access_committee)",
-    "required": ["object_id", "dac_contacts"],
+    "required": ["objectId", "dacContacts"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: an DAC (by using EGA-DAC-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: an DAC (by using EGADACIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that DAC EGA ID (EGAC) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-DAC-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGADACIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the DAC",
         "description": "Short free-form text that can be used to call out DAC records in searches or displays.",
@@ -43,7 +43,7 @@
         "examples": [ "EBI Consortium Data Access Committee" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the DAC",
         "description": "An in-depth description of the DAC, including its overall purpose or nature of studies it governs.",
@@ -51,19 +51,19 @@
         "examples": [ "EBI DAC governing data from projects related to human microbiome with data provenance..." ]
       },
 
-      "dac_contacts": {
+      "dacContacts": {
         "type": "object",
         "title": "DAC contacts' details",
         "description": "Object containing the main contact's and optional additional contact's details.",
         "additionalProperties": false,
-        "required": ["main_contact"],
+        "required": ["mainContact"],
         "properties": {
-          "main_contact": {
+          "mainContact": {
             "title": "Main contact of the DAC",
             "description": "The main contact of that DAC whose contact details will be used first to reach the DAC.",
-            "$ref": "./EGA.common-definitions.json#/definitions/contact_details"
+            "$ref": "./EGA.common-definitions.json#/definitions/contactDetails"
           },
-          "additional_contacts": {
+          "additionalContacts": {
             "type": "array",
             "title": "Additional DAC contacts' details",
             "description": "An array compromising additional contact details to use when in need to reach the DAC yet the main contact is unresponsive or does not exist.",
@@ -71,13 +71,13 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": { 
-              "$ref": "./EGA.common-definitions.json#/definitions/contact_details" 
+              "$ref": "./EGA.common-definitions.json#/definitions/contactDetails" 
             }
           }
         }
       },
 
-      "dac_relationships": {
+      "dacRelationships": {
         "type": "array",
         "title": "DAC relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. a policy being linked to a DAC) the EGA.",
@@ -88,53 +88,53 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a DAC",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a DAC.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetPolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type same_as, grouped_with and member_of (optional ones)",
+                  "title": "Allowed relationships of type sameAs, groupedWith and memberOf (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDAC"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDAC"
                         }
                       ]
                     }
@@ -147,44 +147,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -196,11 +196,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "dac_attributes": {
+      "dacAttributes": {
         "type": "array",
         "title": "DAC custom attributes",
         "description": "Custom attributes of a DAC: reusable attributes to encode tag-value pairs (e.g. Tag being 'Targeted loci' and its Value '5:63256183-63258334') with optional units (e.g. 'base pairs'). Its properties are inherited from the common-definitions.json schema.",
@@ -208,7 +208,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
 

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -121,10 +121,10 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         }
                       ]
                     },
@@ -147,13 +147,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -162,13 +162,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -175,16 +175,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -189,10 +189,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -218,13 +218,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -233,13 +233,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -6,36 +6,36 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its analysis metadata object. This object is intended to contain metadata about a detailed examination of data (mainly data processing protocols) in order to come to some conclusion. It can be of different types (e.g. sequence variation, sequence alignment, phenotype characterization, gene expression, etc.) that will mainly differ in the protocols used to achieve the processed data of the analysis. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_id", "analysis_type_specifications" ],
+    "required": ["objectId", "analysisTypeSpecifications" ],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions.", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions.", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that analysis EGA ID (EGAZ) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-analysis-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAAnalysisIdPattern"
               }
             }
           }
         ]
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the analysis",
         "description": "An informative analysis title that should serve as an overview of the analysis, including: performed analysis, samples, purpose... (e.g. 'Variant calling analysis of tumor repressed cells'). This short text can be used to call out analyses records in searches or in displays.",
@@ -43,7 +43,7 @@
         "examples": [ "Variant calling analysis of tumor repressed cells" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the analysis",
         "description": "An in-depth description of the biological relevance and intent of the analysis, including its workflow.",
@@ -51,7 +51,7 @@
         "examples": [ "The analysis was conducted with the objective of... ...and for that purpose we compared untreated controls against..." ]
       },
 
-      "targeted_loci": {
+      "targetedLoci": {
         "type": "array",
         "title": "Loci of the targeted genomic feature",
         "description": "Array of items that unambiguously define the loci of targeted genomic features in the analysis. For example, if the aim of the analysis was to detect variants in the human gene TAF1 and TP53, their identifiers will be expected in two items of this array.",
@@ -59,11 +59,11 @@
         "uniqueItems": true,
         "additionalProperties": false,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/locus_identifier" 
+          "$ref": "./EGA.common-definitions.json#/definitions/locusIdentifier" 
         }
       },
 
-      "types_of_input_data": {
+      "typesOfInputData": {
         "type": "array",
         "title": "Types of input data",
         "description": "Types of input data the analysis uses to obtain the processed files.",
@@ -71,11 +71,11 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
         }
       },
 
-      "types_of_output_data": {
+      "typesOfOutputData": {
         "type": "array",
         "title": "Types of output data",
         "description": "Types of output data the analysis uses to obtain the processed files.",
@@ -83,18 +83,18 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
         }
       },
 
-      "analysis_type_specifications": {
+      "analysisTypeSpecifications": {
         "type": "object",
         "title": "Analysis type specifications",
         "description": "Node containing different sets of fields that depend on the specific analysis type. Depending on the analysis types different metadata will be required.",
         "additionalProperties": false,
-        "required": ["analysis_types"],
+        "required": ["analysisTypes"],
         "properties": {
-          "analysis_types": {
+          "analysisTypes": {
             "type": "array",
             "title": "List of analysis types",
             "description": "Array of all analysis types applicable to this analysis. Details on how the analysis was performed (instruments, software, procedure...) shall be included in the 'analysis_protocols' field, not here. For example, if the analysis includes sequence variation files (e.g. VCF) that were obtained by a sequencing assay (i.e. from the sequenced reads), at least the analysis type 'sequence variation' would be expected. Furthermore, depending on the types of analysis, different details may be required (e.g. reference sequence details in a 'sequence alignment' type).",
@@ -109,15 +109,15 @@
               "meta:enum": [ "sequence variation__ERO:0100211: Analysis of variations at specific loci in the genomes of organisms (mutation and polymorphism) across or within a species, population, or individual (e.g healthy vs diseased tissue).", "sequence alignment__ERO:0100032: objective to display graphically how the sequences of two or more macromolecules align along a linear axis.", "phenotype characterization__ERO:0000923: The result of an organismal assay that involves characterization of a phenotype; any observable characteristic or trait of an organism: such as its morphology, development, biochemical or physiological properties, behavior, and products of behavior (such as a bird's nest). Phenotypes result from the expression of an organism's genes as well as the influence of environmental factors and the interactions between the two.", "sequence annotation__operation:0361: Analysis where molecular sequence records are annotated with terms from a controlled vocabulary. For submitting sequence annotation files, which are usually 'tab' files. Examples include gene count and OTU tables from metagenomic studies.", "sequence assembly__topic:0196: The assembly of fragments of a DNA sequence to reconstruct the original sequence.", "gene expression__topic:0203: The analysis of levels and patterns of synthesis of gene products (proteins and functional RNA) including interpretation in functional terms of gene expression data." ]
             }
           },
-          "reference_alignment_details": {
+          "referenceAlignmentDetails": {
             "title": "Reference assembly and sequence details",
             "description": "Node containing details of the reference sequence used in the alignment of raw sequences.",
-            "$ref": "./EGA.common-definitions.json#/definitions/reference_alignment_details"
+            "$ref": "./EGA.common-definitions.json#/definitions/referenceAlignmentDetails"
           }
         }
       },
 
-      "analysis_files": {
+      "analysisFiles": {
         "type": "array",
         "title": "Files of the analysis",
         "description": "This property contains the files derived from performing any processing or analysis over raw data (e.g. VCF, aligned BAM...) and those that add context to it (e.g. CSV, TXT...).",
@@ -125,11 +125,11 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-              "$ref": "./EGA.common-definitions.json#/definitions/file_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/fileObject"
         }
       },
 
-      "analysis_relationships": {
+      "analysisRelationships": {
         "type": "array",
         "title": "Analysis relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. an analysis being linked to a Sample) the EGA.",
@@ -140,72 +140,72 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for an analysis",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a analysis.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         }
                       ]
                     }
@@ -218,44 +218,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -267,11 +267,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "analysis_attributes": {
+      "analysisAttributes": {
         "type": "array",
         "title": "Analysis custom attributes",
         "description": "Custom attributes of an analysis: reusable attributes to encode tag-value pairs (e.g. Tag being 'internal tag' and its Value 'this analysis is corresponds to internal tag XYZ') with optional units. Its properties are inherited from the common-definitions.json schema.",
@@ -279,7 +279,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -246,16 +246,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -253,10 +253,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -282,13 +282,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -297,13 +297,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -310,16 +310,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -6,36 +6,36 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its assay metadata object. This object is intended to contain metadata about the raw qualitative or quantitative test performed to determine any kind of biological property of a biological sample. It can be of different types: (1) sequencing assay [EFO:0003740] (e.g. sequence CRAM or FastQ files); and an (2) array assay [EFO:0002696] (e.g. intensity CEL files). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_id", "assay_type_specifications", "assay_files"],
+    "required": ["objectId", "assayTypeSpecifications", "assayFiles"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: an assay (by using EGA-assay-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: an assay (by using EGAAssayIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that assay's EGA ID (EGAR) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-assay-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAAssayIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the assay",
         "description": "An informative assay title that should serve as an overview of the assay and differentiate it from others. This short text can be used to call out assay records in searches or in displays.",
@@ -43,7 +43,7 @@
         "examples": [ "Ilumina sequencing assay 3409 - Cancer genomics" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the assay",
         "description": "An in-depth description (e.g. used technology, sample groups, purpose...) of the assay. ",
@@ -51,7 +51,7 @@
         "examples": [ "Sequencing assay number 3409 of 4000. Sequenced through Illumina MiSeq to find SNPs of colorectal cancer samples..." ]
       },
 
-      "assay_center": {
+      "assayCenter": {
         "type": "string",
         "title": "Centername that performed the assay",
         "description": "The name of the center (e.g. 'EBI-TEST') responsible for performing assay, if applicable, in case it's different from the center submitting metadata).",
@@ -59,21 +59,21 @@
         "examples": [ "EBI-TEST" ]
       },
 
-      "assay_date": {
+      "assayDate": {
         "type": "string",
         "title": "Date of the assay",
         "description": "Date when the sequencing assay took place (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the assay concluded.",
-        "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO8601-date-pattern"
+        "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
       },
 
-      "assay_type_specifications": {
+      "assayTypeSpecifications": {
         "type": "object",
         "title": "Assay type specifications",
-        "description": "Node containing different sets of fields that depend on the specific assay type. The main categories of assay types follow a similar pattern as the used technology: either array assays (those in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used) or sequencing assays (those in which a [sequencing instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used). Depending on the used technology, different types of fields will be required. For example, if an array was used, its sample_array_labels will be expected. Having this modular assay type-related node allows for easy additions of new technology-specific requirements.",
+        "description": "Node containing different sets of fields that depend on the specific assay type. The main categories of assay types follow a similar pattern as the used technology: either array assays (those in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used) or sequencing assays (those in which a [sequencing instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used). Depending on the used technology, different types of fields will be required. For example, if an array was used, its sample_arrayLabels will be expected. Having this modular assay type-related node allows for easy additions of new technology-specific requirements.",
         "additionalProperties": false,
-        "required": ["assay_type"],
+        "required": ["assayType"],
         "properties": {
-          "assay_type": {
+          "assayType": {
             "type": "string",
             "title": "Assay type",
             "description": "The general categories, either sequencing or array, in which assays are categorized based on the used instruments. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -83,51 +83,51 @@
               "sequencing": "An assay in which a [sequencer instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used."
             }
           },
-          "array_assay_specifications": {
+          "arrayAssaySpecifications": {
             "type": "object",
             "title": "Specifications of an array assay",
             "description": "Node containing the set of fields specific to an assay of type 'array' (i.e. an array was used to obtain the raw data).",
             "additionalProperties": false,
-            "required": ["n_labels_per_array"],
+            "required": ["nLabelsPerArray"],
             "properties": {
-              "n_labels_per_array": {
+              "nLabelsPerArray": {
                 "type": "number",
                 "title": "Number of labels per array",
                 "description": "A single array can be prepared with biological materials labelled differently for them to be compared in parallel. Here one shall specify the number of labels used in the single array (e.g. 2 for a Two-colour cDNA microarray). Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
                 "enum": [1, 2, 3, 4],
                 "meta:enum": {
                   "1": "One single label was used for a single array",
-                  "2": "Two labels were used for a single array. The node 'array_sample_labels' specifying which samples were labelled by which compounds will be expected.",
-                  "3": "Three labels were used for a single array. The node 'array_sample_labels' specifying which samples were labelled by which compounds will be expected.",
-                  "4": "Four labels were used for a single array. The node 'array_sample_labels' specifying which samples were labelled by which compounds will be expected."
+                  "2": "Two labels were used for a single array. The node 'arraySampleLabels' specifying which samples were labelled by which compounds will be expected.",
+                  "3": "Three labels were used for a single array. The node 'arraySampleLabels' specifying which samples were labelled by which compounds will be expected.",
+                  "4": "Four labels were used for a single array. The node 'arraySampleLabels' specifying which samples were labelled by which compounds will be expected."
                 }
               },
-              "array_sample_labels": {
+              "arraySampleLabels": {
                 "type": "array",
-                "title": "Array of sample-label pairs of the array assay",
+                "title": "Array of sampleLabel pairs of the array assay",
                 "description": "Sample-Label pairs (e.g. sample 'EGAN00000000001' and label 'Cy3') to know which samples used in this assay are labelled by which chemicals. Can be omitted if the array is of one single label/colour.",
                 "minItems": 1,
                 "additionalProperties": false,
                 "uniqueItems": true,
                 "items": { 
-                  "$ref": "./EGA.common-definitions.json#/definitions/sample-label-association"
+                  "$ref": "./EGA.common-definitions.json#/definitions/sampleLabel-association"
                 }
               }
             },
             "anyOf": [
               {
                 "title": "2 labels per array check",
-                "description": "If two labels were used per array, the sample-label specifications will be expected and at least 2 items (one for each label)",
+                "description": "If two labels were used per array, the sampleLabel specifications will be expected and at least 2 items (one for each label)",
                 "if": {
-                  "required": [ "n_labels_per_array" ],
+                  "required": [ "nLabelsPerArray" ],
                   "properties": {
                     "prueba": { "const": 2 }
                   }
                 },
                 "then": { 
-                  "required": [ "array_sample_labels" ],
+                  "required": [ "arraySampleLabels" ],
                   "properties": {
-                    "array_sample_labels": {
+                    "arraySampleLabels": {
                       "minItems": 2
                     }
                   }
@@ -135,17 +135,17 @@
               },
               {
                 "title": "3 labels per array check",
-                "description": "If three labels were used per array, the sample-label specifications will be expected and at least 3 items (one for each label)",
+                "description": "If three labels were used per array, the sampleLabel specifications will be expected and at least 3 items (one for each label)",
                 "if": {
-                  "required": [ "n_labels_per_array" ],
+                  "required": [ "nLabelsPerArray" ],
                   "properties": {
                     "prueba": { "const": 3 }
                   }
                 },
                 "then": { 
-                  "required": [ "array_sample_labels" ],
+                  "required": [ "arraySampleLabels" ],
                   "properties": {
-                    "array_sample_labels": {
+                    "arraySampleLabels": {
                       "minItems": 3
                     }
                   }
@@ -153,17 +153,17 @@
               },
               {
                 "title": "4 labels per array check",
-                "description": "If four labels were used per array, the sample-label specifications will be expected and at least 4 items (one for each label)",
+                "description": "If four labels were used per array, the sampleLabel specifications will be expected and at least 4 items (one for each label)",
                 "if": {
-                  "required": [ "n_labels_per_array" ],
+                  "required": [ "nLabelsPerArray" ],
                   "properties": {
                     "prueba": { "const": 4 }
                   }
                 },
                 "then": { 
-                  "required": [ "array_sample_labels" ],
+                  "required": [ "arraySampleLabels" ],
                   "properties": {
-                    "array_sample_labels": {
+                    "arraySampleLabels": {
                       "minItems": 4
                     }
                   }
@@ -171,16 +171,16 @@
               }              
             ]
           },
-          "sequencing_assay_specifications": {
+          "sequencingAssaySpecifications": {
             "type": "object",
             "title": "Specifications of a sequencing assay",
             "description": "Node containing the set of fields specific to an assay of type 'sequencing' (i.e. a sequencer was used to obtain the raw data).",
             "additionalProperties": false,
             "properties": {
-              "reference_alignment_details": {
+              "referenceAlignmentDetails": {
                 "title": "Reference assembly and sequence details",
                 "description": "Node containing details of the reference sequence used in the alignment.",
-                "$ref": "./EGA.common-definitions.json#/definitions/reference_alignment_details"
+                "$ref": "./EGA.common-definitions.json#/definitions/referenceAlignmentDetails"
               }
             }
           }
@@ -189,21 +189,21 @@
           {
             "title": "If the assay is of type array its specifications will be expected",
             "if": {
-              "required": ["assay_type"],
+              "required": ["assayType"],
               "properties": {
-                "assay_type": {
+                "assayType": {
                       "enum": ["array"]
                 }
               }
             },
             "then": {
-              "required": ["array_assay_specifications"]
+              "required": ["arrayAssaySpecifications"]
             }
           }
         ]
       },
 
-      "assay_relationships": {
+      "assayRelationships": {
         "type": "array",
         "title": "Assay relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities, one of which shall be the current assay.",
@@ -214,62 +214,62 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for an assay",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a XXXXX.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
                         }
                       ]
                     }
@@ -282,44 +282,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -331,11 +331,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "assay_files": {
+      "assayFiles": {
         "type": "array",
         "title": "Data files produced from an assay",
         "description": "This property contains the specific files (e.g. raw CRAM files) derived from performing the sequencing or hybridization and scanning with the sampled material.",
@@ -346,17 +346,17 @@
           "allOf": [
             {
               "title": "Basic file object",
-              "$ref": "./EGA.common-definitions.json#/definitions/file_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/fileObject"
             },
             {
               "title": "Constraint of filetypes that are allowed for an assay",
-              "$ref": "./EGA.common-definitions.json#/definitions/assay-filetypes"
+              "$ref": "./EGA.common-definitions.json#/definitions/assayFiletypes"
             }
           ]              
         }
       },
 
-      "assay_attributes": {
+      "assayAttributes": {
         "type": "array",
         "title": "Assay custom attributes",
         "description": "Custom attributes of an assay: reusable attributes to encode tag-value pairs (e.g. Tag being 'additional context' and its Value 'this specific assay was stored mistakenly for longer periods of time, so its data could be misleading...') with optional units. Its properties are inherited from the common-definitions.json schema.",
@@ -364,7 +364,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
 
@@ -374,7 +374,7 @@
         "title": "If the files are aligned reads, the reference alignment details are expected",
         "if": {
           "properties": {
-            "assay_files": {
+            "assayFiles": {
               "items": {
                 "properties": {
                   "filetype": {
@@ -387,11 +387,11 @@
         },
         "then": {
           "properties": {
-            "assay_type_specifications": {
-              "required": ["sequencing_assay_specifications"],
+            "assayTypeSpecifications": {
+              "required": ["sequencingAssaySpecifications"],
               "properties": {
-                "sequencing_assay_specifications": {
-                  "required": ["reference_alignment_details"]
+                "sequencingAssaySpecifications": {
+                  "required": ["referenceAlignmentDetails"]
                 }
               }
             }
@@ -402,9 +402,9 @@
         "title": "Allowed filetypes for a sequencing assay",
         "if": {
           "properties": {
-            "assay_type_specifications": {
+            "assayTypeSpecifications": {
               "properties": {
-                "assay_type": {
+                "assayType": {
                   "const": "sequencing"
                 }
               }
@@ -413,7 +413,7 @@
         },
         "then": {
           "properties": {
-            "assay_files": {
+            "assayFiles": {
               "items": {
                 "properties": {
                   "filetype": {
@@ -429,9 +429,9 @@
         "title": "Allowed filetypes for an array assay",
         "if": {
           "properties": {
-            "assay_type_specifications": {
+            "assayTypeSpecifications": {
               "properties": {
-                "assay_type": {
+                "assayType": {
                   "const": "array"
                 }
               }
@@ -440,7 +440,7 @@
         },
         "then": {
           "properties": {
-            "assay_files": {
+            "assayFiles": {
               "items": {
                 "properties": {
                   "filetype": {

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -2144,7 +2144,7 @@
         ]
       },
 
-      "sampleLabel-association": {
+      "sampleLabelAssociation": {
         "type": "object",
         "title": "Repeatable Sample-label node",
         "description": "The base node of a label-sample association. One form of basic identification of the sample (inherited from objectCoreId - e.g. either the center name and alias or the accession) is required, as well as the label per se.",
@@ -3283,7 +3283,7 @@
         }
       },
 
-      "r-type-groupedWith": {
+      "rTypeGroupedWith": {
         "type": "object",
         "title": "Relationship type: groupedWith",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3295,7 +3295,7 @@
         }
       },
 
-      "r-type-memberOf": {
+      "rTypeMemberOf": {
         "type": "object",
         "title": "Relationship type: memberOf",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3307,7 +3307,7 @@
         }
       },
 
-      "r-type-isAfter": {
+      "rTypeIsAfter": {
         "type": "object",
         "title": "Relationship type: isAfter",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3319,7 +3319,7 @@
         }
       },
 
-      "r-type-childOf": {
+      "rTypeChildOf": {
         "type": "object",
         "title": "Relationship type: childOf",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3331,7 +3331,7 @@
         }
       },
 
-      "r-type-developsFrom": {
+      "rTypeDevelopsFrom": {
         "type": "object",
         "title": "Relationship type: developsFrom",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3343,7 +3343,7 @@
         }
       },
 
-      "r-type-familyRelationshipWith": {
+      "rTypeFamilyRelationshipWith": {
         "type": "object",
         "title": "Relationship type: familyRelationshipWith",
         "description": "Node to be used as a relationship type for relationship contraints.",
@@ -3655,7 +3655,7 @@
         }
       },
 
-      "r-source-externalAccession": {
+      "rSourceExternalAccession": {
         "type": "object",
         "title": "Relationship source: externalAccession",
         "description": "Node to be used as an object type for relationship contraints.",
@@ -3671,7 +3671,7 @@
         }
       },
 
-      "r-target-externalAccession": {
+      "rTargetExternalAccession": {
         "type": "object",
         "title": "Relationship target: externalAccession",
         "description": "Node to be used as an object type for relationship contraints.",
@@ -3683,11 +3683,11 @@
                 "const": "externalAccession" 
               }
             }
-          } 
+          }
         }
       },
 
-      "r-source-externalURL": {
+      "rSourceExternalURL": {
         "type": "object",
         "title": "Relationship source: externalURL",
         "description": "Node to be used as an object type for relationship contraints.",
@@ -3703,7 +3703,7 @@
         }
       },
 
-      "r-target-externalURL": {
+      "rTargetExternalURL": {
         "type": "object",
         "title": "Relationship target: externalURL",
         "description": "Node to be used as an object type for relationship contraints.",

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -5,9 +5,9 @@
     "title": "EGA common metadata definitions",
     "meta:version": "0.0.0",
     "$async": true,
-    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to store common definitions for other metadata objects. Basically, we are defining here common properties (e.g. instances' aliases) that other metadata objects (e.g. sample) may use. The way we refer to them is by using this object's '$id' field, referencing it in other files (with '$ref' and the relative path of the property - e.g. '$ref': 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/object_core_id'). See structuring documentation (https://json-schema.org/understanding-json-schema/structuring.html). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
+    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to store common definitions for other metadata objects. Basically, we are defining here common properties (e.g. instances' aliases) that other metadata objects (e.g. sample) may use. The way we refer to them is by using this object's '$id' field, referencing it in other files (with '$ref' and the relative path of the property - e.g. '$ref': 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/objectCoreId'). See structuring documentation (https://json-schema.org/understanding-json-schema/structuring.html). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
     "definitions": {
-      "object_core_id": {
+      "objectCoreId": {
         "type": "object",
         "title": "Core identifiers of an object",
         "description": "Base definition containing the properties (e.g. Sample's alias) of a minimal identification layer of an EGA object (e.g. Sample).",
@@ -20,20 +20,20 @@
             "minLength": 1,
             "examples": [ "my_sample_J13" ]
           },
-          "center_name": {
+          "centerName": {
             "type": "string",
             "title": "Center name of the submitter",
             "description": "Center name (e.g. 'EBI-TEST') associated to the submitter. In other words, it is the acronym of the submitter's account (provided by the HelpDesk team).",
             "minLength": 1,
             "examples": [ "EBI-TEST" ]
           },
-          "ega_accession": {
+          "egaAccession": {
             "type": "string",
             "title": "EGA's accession of the object",
             "description": "The object accession (i.e. unique identifier) assigned by the archive (EGA). Object accessions can be found in the 'Identifiers' section of the EGA-archive website (https://ega-archive.org/metadata/how-to-use-the-api) and commonly start with EGA, followed by the distinctive letter of the object and finally the numeric ID of the instance.",
             "examples": [ "EGAN00003245489" ]
           },
-          "external_accessions": {
+          "externalAccessions": {
             "type": "array",
             "title": "External accessions array",
             "description": "External accession node to reference objects in other archives (e.g. an already existing sample at BioSamples).",
@@ -41,7 +41,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/object_external_accession"
+              "$ref": "./EGA.common-definitions.json#/definitions/objectExternalAccession"
             }
           }
 
@@ -49,20 +49,20 @@
         "anyOf": [
           { 
             "title": "Check core IDs: combination of Alias and Center name",
-            "required": ["alias", "center_name"] 
+            "required": ["alias", "centerName"] 
           },
           { 
             "title": "Check core IDs: EGA accession ID",
-            "required": ["ega_accession"] 
+            "required": ["egaAccession"] 
           },
           { 
             "title": "Check core IDs: external accessions",
-            "required": ["external_accessions"] 
+            "required": ["externalAccessions"] 
           }
         ]
       },
 
-      "custom_attribute": {
+      "customAttribute": {
         "type": "object",
         "title": "Custom attribute of an object",
         "description": "Reusable attributes to encode tag-value pairs (e.g. Tag being 'Age' and its Value '40') with optional units (e.g. 'years').",
@@ -92,22 +92,22 @@
         }        
       },
 
-      "file_object": {
+      "fileObject": {
         "type": "object",
         "title": "EGA File object",
         "description": "Object containing the base metadata attributes of a file object in the EGA. These can inherited elsewhere with or without extending them.",
-        "required": ["filename", "filetype", "checksum_method", "unencrypted_checksum", "encrypted_checksum"],
+        "required": ["filename", "filetype", "checksumMethod", "unencryptedChecksum", "encryptedChecksum"],
         "additionalProperties": false,
         "properties": {
           "filename": {
             "type": "string",
             "title": "Filename",
-            "meta:property_curie": "data:1050",
+            "meta:propertyCurie": "data:1050",
             "description": "The full name of a file, including all of their file extensions (e.g. .gpg, .md5...), that identifies the file (e.g. 'my-bam-file.bam.gpg').",
             "pattern": "^[^<>:;,?\"*|]+$",
             "examples": [ "my-bam-file.bam.gpg" ]
           },
-          "file_content": {
+          "fileContent": {
             "type": "array",
             "title": "File content array",
             "description": "Array of file content items. This array exists to clarify what the purpose of a file, regardless of its format, may be. For example, a TXT formatted file could contain multiple types of data, from gene annotations to READMEs. Therefore, select the items from the used ontology that best describe the content of your file.",
@@ -118,17 +118,17 @@
               "type": "object",
               "title": "File content item",
               "description": "Item describing the type of data a file contains or represents.",
-              "meta:property_curie": "format:2350",
-              "required": ["type_of_data_curie"],
+              "meta:propertyCurie": "format:2350",
+              "required": ["typeOfDataCurie"],
               "additionalProperties": false,
               "properties": {
-                "type_of_data_curie": {
+                "typeOfDataCurie": {
                   "type": "string",
                   "title": "Compact URI (CURIE) of the type of data.",
                   "allOf": [
                     {
                       "title": "General CURIE pattern",
-                      "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                      "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
                     }
                   ],
                   "graphRestriction ":  {
@@ -140,7 +140,7 @@
                   },
                   "examples": [ "format:1919", "format:3326" ]
                 },
-                "type_of_data_term": {
+                "typeOfDataTerm": {
                   "type": "string",
                   "title": "Term of the type of data",
                   "description": "Term that specifies the type of data content.",
@@ -153,7 +153,7 @@
           "filetype": {
             "type": "string",
             "title": "Filetype",
-            "meta:property_curie": "format:1915",
+            "meta:propertyCurie": "format:1915",
             "description": "The main format in which data is structured and represented in an electronic file. It is normally defined by the file extension of the file (e.g. FASTQ for a '.fastq' file). The string corresponds to the ID or name (e.g. FASTA, TSV...), chosen from a list of controlled vocabulary (CV), associated with the given filetype. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
             "enum": ["CEL", "TSV", "FASTQ", "FASTA", "VCF", "SRA", "SRF", "SFF", "BAM", "CRAM", "XLSX", "CSV", "BED", "IDAT", "MAP", "PED", "BIM", "FAM", "TXT", "EXP", "GPR", "PY", "SH", "ADF", "SDRF", "IDF", "MD5", "HAP", "CSFASTA", "LOC", "HTML", "HIC", "MD", "MATLAB", "PERL", "TIF", "R", "SNP", "XML", "SVG", "PNG", "JPG", "GTC", "HDF5", "FAST5", "PAIR", "TXT", "BGI", "BGEN", "GEN", "PXF", "LOOM", "BAX.H5", "BAS.H5", "ASM", "CSI", "TBI", "BCF", "qual454", "qualsolid", "FASTQ-illumina", "FASTQ-helicos", "FASTQ-sanger", "FASTQ-solexa", "SAM", "CRAI", "BAI", "MTX", "MEX ", "GMX", "GMT", "GRP"],
             "meta:enum": {
@@ -230,10 +230,10 @@
               "GRP": "[]"
             }
           },
-          "checksum_method": {
+          "checksumMethod": {
             "type": "string",
             "title": "Checksum method ID",
-            "meta:property_curie": "REPR:ChecksumAlgorithm",
+            "meta:propertyCurie": "REPR:ChecksumAlgorithm",
             "description": "Node containing both the ID (MD5 or SHA-256), describing the method which yields the checksum from a data input for the purpose of detecting errors. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
             "enum": ["MD5", "SHA-256"],
             "meta:enum": {
@@ -241,7 +241,7 @@
               "SHA-256": "[NCIT:C80226]"
             }
           },
-          "unencrypted_checksum": {
+          "unencryptedChecksum": {
             "type": "string",
             "title": "Checksum [NCIT:C43522] of the unencrypted file",
             "description": "A computed value which depends on the contents of a block of data and which is transmitted or stored along with the data in order to detect corruption of the data, computed from the unencrypted files.",
@@ -249,15 +249,15 @@
             "oneOf": [
               { 
                 "title": "Check of MD5 checksum pattern", 
-                "$ref": "#/definitions/md5-checksum-pattern"
+                "$ref": "#/definitions/md5ChecksumPattern"
               },
               { 
                 "title": "Check of SHA-256 checksum pattern",
-                "$ref": "#/definitions/SHA-256-checksum-pattern"
+                "$ref": "#/definitions/SHA256ChecksumPattern"
               }
             ]
           },
-          "encrypted_checksum": {
+          "encryptedChecksum": {
             "type": "string",
             "title": "Checksum [NCIT:C43522] of the encrypted file",
             "description": "A computed value which depends on the contents of a block of data and which is transmitted or stored along with the data in order to detect corruption of the data, computed from the encrypted files.",
@@ -265,32 +265,32 @@
             "oneOf": [
               { 
                 "title": "Check of MD5 checksum pattern", 
-                "$ref": "#/definitions/md5-checksum-pattern"
+                "$ref": "#/definitions/md5ChecksumPattern"
               },
               { 
                 "title": "Check of SHA-256 checksum pattern",
-                "$ref": "#/definitions/SHA-256-checksum-pattern"
+                "$ref": "#/definitions/SHA256ChecksumPattern"
               }
             ]
           },
-          "sequence_quality_details": {
+          "sequenceQualityDetails": {
             "type": "object",
             "title": "Sequence quality details",
             "description": "Sequencing quality scores measure the probability that a base is called (i.e. sequenced) incorrectly. New sequencing technologies assign a quality score to each of the bases in the sequence.",
-            "required": ["quality_scoring_system"],
+            "required": ["qualityScoringSystem"],
             "additionalProperties": false,
             "properties": {
-              "quality_scoring_system": {
+              "qualityScoringSystem": {
                 "type": "string",
                 "title": "Quality scoring system",
                 "description": "How the quality score was computed for the data.",
-                "enum": ["phred", "log-odds"],
+                "enum": ["phred", "logOdds"],
                 "meta:enum": { 
                   "phred": "The quality score is expressed as a probability of error in log form: -10 log(1/p) where p is the probability of error, with value range 0..63 (0 meaning no base call).",
-                  "log-odds": "The quality score is expressed as the ratio of error to non-error in log form: -10 log(p/(1-p)) where p is the of error, with value range -40..40. The SRA will convert these into phred scale during loadtime." 
+                  "logOdds": "The quality score is expressed as the ratio of error to non-error in log form: -10 log(p/(1-p)) where p is the of error, with value range -40..40. The SRA will convert these into phred scale during loadtime." 
                 }
               },
-              "quality_encoding": {
+              "qualityEncoding": {
                 "type": "string",
                 "title": "Quality encoding format",
                 "description": "Encoding system used to represent the quality score.",
@@ -301,7 +301,7 @@
                   "hexadecimal": "Single hexadecimal value per quality score."
                 }
               },
-              "ascii_offset": {
+              "asciiOffset": {
                 "type": "string",
                 "title": "ASCII offset",
                 "description": "Character used in representing the minimum quality value.  Helps specify how to decode text rendering of quality data.",
@@ -317,66 +317,66 @@
         "allOf": [
           { 
             "title": "Inherited check of checksum patterns", 
-            "$ref": "#/definitions/checksum-pattern-check" 
+            "$ref": "#/definitions/checksumPatternCheck" 
           },
           { 
             "title": "Inherited check of filetype-filename patterns", 
-            "$ref": "#/definitions/filename-filetype-pattern-check" 
+            "$ref": "#/definitions/filenameFiletypePatternCheck" 
           }
         ]        
       },
 
-      "relationship_object": {
+      "relationshipObject": {
         "type": "object",
         "title": "EGA Relationships object",
         "description": "Object containing the base metadata attributes of a relationship object in the EGA. Comprises metadata (e.g. Source or Target) of a directional association between two entities. One of the entitis **needs** to be the current instance. For instance, a study JSON document should not contain relationships between a sample and an individual. Therefore, only one end of the relationship is given: if the source is present, the target is inferred to be the current instance; if the target is given, then it's the source the one inferred as the current instance. Examples of common relationships: (1) a sample being referenced in an experiment; (2) an study being the same as another study at a different archive (e.g. in BioStudies); (3) an individual being the parent of another individual; (4) hundreds of samples being grouped with each other for broad reasons.",
-        "required": ["r_type"],
+        "required": ["rType"],
         "additionalProperties": false,
         "properties": {
-          "r_type": {
+          "rType": {
             "type": "string",
             "title": "Relationship type",
-            "description": "ID (e.g. same_as) of the type of the relationship. To be chosen from a controlled vocabulary (CV) list. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema) proposing its addition.",
-            "enum": ["referenced_by", "develops_from", "same_as", "member_of", "grouped_with", "family_relationship_with", "child_of", "is_after", "published_in", "submitted_by", "contact_of", "main_contact_of"],
+            "description": "ID (e.g. sameAs) of the type of the relationship. To be chosen from a controlled vocabulary (CV) list. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema) proposing its addition.",
+            "enum": ["referencedBy", "developsFrom", "sameAs", "memberOf", "groupedWith", "familyRelationshipWith", "childOf", "isAfter", "publishedIn", "submittedBy", "contactOf", "mainContactOf"],
             "meta:enum": {
-              "referenced_by": "[SIO:000252]",
-              "develops_from": "[RO:0002202]",
-              "same_as": "[NCIT:C64637]",
-              "member_of": "[RO:0002350]",
-              "grouped_with": "",
-              "family_relationship_with": "[EFO:0004424]",
-              "child_of": "[GSSO:000728]",
-              "is_after": "[SIO:000211]",
-              "published_in": "[EFO:0001796]",
-              "submitted_by": "[NCIT:C25695]",
-              "contact_of": "[NCIT:C25461]",
-              "main_contact_of": "" 
+              "referencedBy": "[SIO:000252]",
+              "developsFrom": "[RO:0002202]",
+              "sameAs": "[NCIT:C64637]",
+              "memberOf": "[RO:0002350]",
+              "groupedWith": "",
+              "familyRelationshipWith": "[EFO:0004424]",
+              "childOf": "[GSSO:000728]",
+              "isAfter": "[SIO:000211]",
+              "publishedIn": "[EFO:0001796]",
+              "submittedBy": "[NCIT:C25695]",
+              "contactOf": "[NCIT:C25461]",
+              "mainContactOf": "" 
             },
-            "examples": [ "referenced_by" ]
+            "examples": [ "referencedBy" ]
           },
-          "r_source": {
+          "rSource": {
             "type": "object",
             "title": "Source of the relationship",
-            "description": "Object reference of the relationship's source. In other words, the starting point of the relationship: in 'sample_A develops_from sample_B' the source is 'sample_A'.",
+            "description": "Object reference of the relationship's source. In other words, the starting point of the relationship: in 'sample_A developsFrom sample_B' the source is 'sample_A'.",
             "allOf": [
               {
-                "title": "Inherited one-relationship-end object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/one-relationship-end" 
+                "title": "Inherited oneRelationshipEnd object", 
+                "$ref": "./EGA.common-definitions.json#/definitions/oneRelationshipEnd" 
               }
             ]
           },
-          "r_target": {
+          "rTarget": {
             "type": "object",
             "title": "Target of the relationship",
-            "description": "Object reference of the relationship's target. In other words, the ending point of the relationship: in 'sample_A develops_from sample_B' the target is 'sample_B'.",
+            "description": "Object reference of the relationship's target. In other words, the ending point of the relationship: in 'sample_A developsFrom sample_B' the target is 'sample_B'.",
             "allOf": [
               {
-                "title": "Inherited one-relationship-end object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/one-relationship-end" 
+                "title": "Inherited oneRelationshipEnd object", 
+                "$ref": "./EGA.common-definitions.json#/definitions/oneRelationshipEnd" 
               }
             ]
           },
-          "r_label": {
+          "rLabel": {
             "type": "string",
             "title": "Custom label of the relationship",
             "description": "Custom free-form label of the relationship, used to add extra details of the relationship if needed.",
@@ -391,41 +391,41 @@
         "oneOf": [
           {
             "title": "The source is given (i.e. the target is inferred as the current instance)",
-            "required": ["r_source"]
+            "required": ["rSource"]
           },
           {
             "title": "The target is given (i.e. the source is inferred as the current instance)",
-            "required": ["r_target"]
+            "required": ["rTarget"]
           }
         ]       
       },
 
-      "array_label": {
+      "arrayLabel": {
         "type": "object",
-        "title": "Repeatable array_label node",
+        "title": "Repeatable arrayLabel node",
         "description": "Chemicals conjugated to nucleic acid/proteins to label them before microarray hybridisation. This node corresponds to the basic description of one single label, and thus should be repeated as an array where inherited if multiple labels are intended to be described. Its basic structure is a label ID and its optional CURIE.",
-        "required": ["array_label_id"],
+        "required": ["arrayLabelId"],
         "additionalProperties": false,
         "properties": {
-          "array_label_id": {
+          "arrayLabelId": {
           "type": "string",
           "title": "Array label of the array experiment - ID",
           "description": "ID/name (e.g. 'Cy3 dye' or 'Biotin') of the Array label used for the experiment.",
           "examples": [ "Cy3 dye" ]
           },
-          "array_label_curie": {
+          "arrayLabelCurie": {
             "type": "string",
             "title": "Array label of the array experiment - CURIE",
             "description": "CURIE (i.e. ontologized term - e.g. 'CHEBI:37987' or 'CHEBI:15956') of the Array label used for the experiment. Search for the ontologized term at the [Ontology Lookup Service (OLS)](https://www.ebi.ac.uk/ols/index).",
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "examples": [ "CHEBI:37987" ]
           },
-          "label_description": {
+          "labelDescription": {
             "type": "string",
             "title": "Array label of the array experiment - Description",
             "description": "Additional description of the used label, indicating further details: context, purpose of the label, description of the label in the absence of an ontologized term, etc.",
@@ -437,182 +437,182 @@
         }
       },
 
-      "object-id-and-object-type-check": {
+      "objectIdAndObjectTypeCheck": {
         "type": "object",
-        "title": "Check that the object_id's accession pattern and object_type match",
-        "description": "This object exists with the only purpose of being a reference as a pattern check of a given object_id and object_type. The constraint consists in asserting that, if the object identifier is an EGA accession, its pattern matches the object type (e.g. if object_type is 'sample', its EGA accession needs to match '^EGAN[0-9]{11}$')",
+        "title": "Check that the objectId's accession pattern and objectType match",
+        "description": "This object exists with the only purpose of being a reference as a pattern check of a given objectId and objectType. The constraint consists in asserting that, if the object identifier is an EGA accession, its pattern matches the object type (e.g. if objectType is 'sample', its EGA accession needs to match '^EGAN[0-9]{11}$')",
         "anyOf": [
           {
-            "title": "Alias and Centername: object_id and object_type check",
-            "description": "A check that ensures that the alias and centername are given as the object_type. Since the alias and centername cannot be checked for specific object_types (i.e. each can name their objects in different ways), this block exists here just so that this option is allowed.",
+            "title": "Alias and Centername: objectId and objectType check",
+            "description": "A check that ensures that the alias and centername are given as the objectType. Since the alias and centername cannot be checked for specific objectTypes (i.e. each can name their objects in different ways), this block exists here just so that this option is allowed.",
             "properties": {
-              "object_id": { 
-                "required": ["alias", "center_name"]
+              "objectId": { 
+                "required": ["alias", "centerName"]
               }
             }
           },
           {
-            "title": "External accession: object_id and object_type check",
-            "description": "A check that ensures that, if 'external_accession' is given as the object_type, the corresponding node exists within object_id",
+            "title": "External accession: objectId and objectType check",
+            "description": "A check that ensures that, if 'externalAccession' is given as the objectType, the corresponding node exists within objectId",
             "properties": {
-              "object_id": { 
-                "required": ["external_accessions"]
+              "objectId": { 
+                "required": ["externalAccessions"]
               },
-              "object_type": {
-                "enum": ["external_accession"]
+              "objectType": {
+                "enum": ["externalAccession"]
               }
             }
           },
           {
-            "title": "Experiment: object_id and object_type check",
-            "description": "A check that ensures that, if 'experiment' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Experiment: objectId and objectType check",
+            "description": "A check that ensures that, if 'experiment' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-experiment-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAExperimentIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["experiment"]
               }
             }
           }, 
           {
-            "title": "Study: object_id and object_type check",
-            "description": "A check that ensures that, if 'study' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Study: objectId and objectType check",
+            "description": "A check that ensures that, if 'study' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-study-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAStudyIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["study"]
               }
             }
           },          
           {
-            "title": "Sample: object_id and object_type check",
-            "description": "A check that ensures that, if 'sample' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Sample: objectId and objectType check",
+            "description": "A check that ensures that, if 'sample' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-sample-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGASampleIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["sample"]
               }
             }
           },          
           {
-            "title": "Submission: object_id and object_type check",
-            "description": "A check that ensures that, if 'submission' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Submission: objectId and objectType check",
+            "description": "A check that ensures that, if 'submission' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-submission-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGASubmissionIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["submission"]
               }
             }
           },          
           {
-            "title": "Assay: object_id and object_type check",
-            "description": "A check that ensures that, if 'assay' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Assay: objectId and objectType check",
+            "description": "A check that ensures that, if 'assay' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-assay-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAAssayIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["assay"]
               }
             }
           },          
           {
-            "title": "Dataset: object_id and object_type check",
-            "description": "A check that ensures that, if 'dataset' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Dataset: objectId and objectType check",
+            "description": "A check that ensures that, if 'dataset' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-dataset-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGADatasetIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["dataset"]
               }
             }
           },          
           {
-            "title": "Analysis: object_id and object_type check",
-            "description": "A check that ensures that, if 'analysis' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Analysis: objectId and objectType check",
+            "description": "A check that ensures that, if 'analysis' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-analysis-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAAnalysisIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["analysis"]
               }
             }
           },          
           {
-            "title": "Policy: object_id and object_type check",
-            "description": "A check that ensures that, if 'policy' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Policy: objectId and objectType check",
+            "description": "A check that ensures that, if 'policy' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-policy-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAPolicyIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["policy"]
               }
             }
           },          
           {
-            "title": "DAC: object_id and object_type check",
-            "description": "A check that ensures that, if 'DAC' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "DAC: objectId and objectType check",
+            "description": "A check that ensures that, if 'DAC' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-DAC-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGADACIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["DAC"]
               }
             }
           },
           {
-            "title": "Individual: object_id and object_type check",
-            "description": "A check that ensures that, if 'individual' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Individual: objectId and objectType check",
+            "description": "A check that ensures that, if 'individual' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-individual-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAIndividualIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["individual"]
               }
             }
           },
           {
-            "title": "Protocol: object_id and object_type check",
-            "description": "A check that ensures that, if 'protocol' is given as the object_type and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
+            "title": "Protocol: objectId and objectType check",
+            "description": "A check that ensures that, if 'protocol' is given as the objectType and an EGA accession for it is given, it matches the corresponding EGA ID pattern.",
             "properties": {
-              "object_id": { 
+              "objectId": { 
                 "properties": {
-                  "ega_accession": { "$ref": "#/definitions/EGA-protocol-id-pattern" }
+                  "egaAccession": { "$ref": "#/definitions/EGAProtocolIdPattern" }
                 }
               },
-              "object_type": {
+              "objectType": {
                 "enum": ["protocol"]
               }
             }
@@ -620,37 +620,37 @@
         ]                      
       },
       
-      "checksum-pattern-check": {
+      "checksumPatternCheck": {
         "type": "object",
         "title": "Check: checksum checks based on its method",
         "description": "This object exists with the only purpose of being a reference of pattern checks of the given checksum (e.g. 'c6779ec2960296ed9a04f08d67f64423') of a file based on its corresponding method (e.g. if the given checksum method is 'MD5' the checksum shall fit into MD5's format of '^[0-9a-z](?:-?[0-9a-z]){31}$')",
         "anyOf": [
           { 
             "title": "Checksum pattern check - MD5",
-            "description": "A check that ensures that, if MD5 is given as a checksum_method_id, the checksums per se (e.g. unencrypted_checksum) follow MD5 patterns (md5-checksum-pattern).",
+            "description": "A check that ensures that, if MD5 is given as a checksumMethodId, the checksums per se (e.g. unencryptedChecksum) follow MD5 patterns (md5ChecksumPattern).",
               "properties": {
-                "checksum_method": {
+                "checksumMethod": {
                       "enum": ["MD5"]
                 },
-                "unencrypted_checksum": { "$ref": "#/definitions/md5-checksum-pattern" },
-                "encrypted_checksum": { "$ref": "#/definitions/md5-checksum-pattern" }
+                "unencryptedChecksum": { "$ref": "#/definitions/md5ChecksumPattern" },
+                "encryptedChecksum": { "$ref": "#/definitions/md5ChecksumPattern" }
               }
           },
           { 
             "title": "Checksum pattern check - SHA-256",
-            "description": "A check that ensures that, if SHA-256 is given as a checksum_method_id, the checksums per se (e.g. unencrypted_checksum) follow SHA-256 patterns (sha-256-checksum-pattern).",
+            "description": "A check that ensures that, if SHA-256 is given as a checksumMethodId, the checksums per se (e.g. unencryptedChecksum) follow SHA-256 patterns (sha-256-checksum-pattern).",
               "properties": {
-                "checksum_method": {
+                "checksumMethod": {
                       "enum": ["SHA-256"]
                 },
-                "unencrypted_checksum": { "$ref": "#/definitions/SHA-256-checksum-pattern" },
-                "encrypted_checksum": { "$ref": "#/definitions/SHA-256-checksum-pattern" }
+                "unencryptedChecksum": { "$ref": "#/definitions/SHA256ChecksumPattern" },
+                "encryptedChecksum": { "$ref": "#/definitions/SHA256ChecksumPattern" }
               }
           }
         ]                    
       },
 
-      "md5-checksum-pattern": {
+      "md5ChecksumPattern": {
         "type": "string",
         "title": "Checksum pattern obtained by MD5",
         "description": "This object exists to hold the pattern that a checksum would have if it was obtained using the algorithm MD5, for it to be referenced elsewhere within this (or other) JSON schema.",
@@ -658,7 +658,7 @@
         "examples": [ "bc527343c7ffc103111f3a694b004e2f" ]
       },
 
-      "SHA-256-checksum-pattern": {
+      "SHA256ChecksumPattern": {
         "type": "string",
         "title": "Checksum pattern obtained by SHA-256",
         "description": "This object exists to hold the pattern that a checksum would have if it was obtained using the algorithm SHA-256, for it to be referenced elsewhere within this (or other) JSON schema.",
@@ -666,84 +666,84 @@
         "examples": [ "c01b39c7a35ccc3b081a3e83d2c71fa9a767ebfeb45c69f08e17dfe3ef375a7b" ]
       },
 
-      "EGA-experiment-id-pattern": {
+      "EGAExperimentIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA experiment's ID (EGAX...)",
         "pattern": "^EGAX[0-9]{11}$",
         "examples": [ "EGAX00002189113" ]
       },
       
-      "EGA-study-id-pattern": {
+      "EGAStudyIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA study's ID (EGAS...)",
         "pattern": "^EGAS[0-9]{11}$",
         "examples": [ "EGAS00001004508" ]
       },
 
-      "EGA-sample-id-pattern": {
+      "EGASampleIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA sample's ID (EGAN...)",
         "pattern": "^EGAN[0-9]{11}$",
         "examples": [ "EGAN00003245489" ]
       },
 
-      "EGA-submission-id-pattern": {
+      "EGASubmissionIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA submission's ID (EGAB...)",
         "pattern": "^EGAB[0-9]{11}$",
         "examples": [ "EGAB00001001831" ]
       },
 
-      "EGA-assay-id-pattern": {
+      "EGAAssayIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA assay's ID (EGAR...)",
         "pattern": "^EGAR[0-9]{11}$",
         "examples": [ "EGAR00001314547" ]
       },
 
-      "EGA-dataset-id-pattern": {
+      "EGADatasetIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA dataset's ID (EGAD...)",
         "pattern": "^EGAD[0-9]{11}$",
         "examples": [ "EGAD00001004170" ]
       },
 
-      "EGA-analysis-id-pattern": {
+      "EGAAnalysisIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA analysis's ID (EGAZ...)",
         "pattern": "^EGAZ[0-9]{11}$",
         "examples": [ "EGAZ00001004170" ]
       },
 
-      "EGA-policy-id-pattern": {
+      "EGAPolicyIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA policy's ID (EGAP...)",
         "pattern": "^EGAP[0-9]{11}$",
         "examples": [ "EGAP00001001831" ]
       },
 
-      "EGA-DAC-id-pattern": {
+      "EGADACIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA DAC's ID (EGAC...)",
         "pattern": "^EGAC[0-9]{11}$",
         "examples": [ "EGAC00001000908" ]
       },
 
-      "EGA-individual-id-pattern": {
+      "EGAIndividualIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA Individual's ID (EGAI...)",
         "pattern": "^EGAI[0-9]{11}$",
         "examples": [ "EGAI00001159712" ]
       },
 
-      "EGA-protocol-id-pattern": {
+      "EGAProtocolIdPattern": {
         "type": "string",
         "title": "Pattern of an EGA protocol's ID (EGAO...)",
         "pattern": "^EGAO[0-9]{11}$",
         "examples": [ "EGAO00001159483" ]
       },
       
-      "EGA-ISO8601-date-pattern": {
+      "EGAISO8601DatePattern": {
         "type": "string",
         "title": "Pattern of EGA ISO 8601 date",
         "description": "Regular expression to check the syntax of a date following 'ISO 8601 date' format. Notice that the Time (denoted by 'T...') is optional. So is the time zone, specified at the end of the string (e.g. 'Z', '+01:00'...). See more detail at 'https://regexpattern.com/iso-8601-dates-times/'.",
@@ -751,7 +751,7 @@
         "examples": [ "2021-04-30", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
       },
 
-      "EGA-ISO8601-duration-pattern": {
+      "EGAISO8601DurationPattern": {
         "type": "string",
         "title": "Pattern of a partial EGA ISO 8601 duration",
         "description": "Pattern of ISO 8601 durations. It can be used to define time intervals (e.g. 'P3Y6M4DT12H30M5S' represents a duration of three years, six months, four days, twelve hours, thirty minutes, and five seconds). See more at https://en.wikipedia.org/wiki/ISO_8601#Durations.",
@@ -759,663 +759,663 @@
         "examples": [ "P3Y6M4DT12H30M5S", "P23DT23H", "PT0S", "P0D", "P0,5Y", "P0.5Y"]
       },
 
-      "filename-filetype-pattern-check": {
+      "filenameFiletypePatternCheck": {
         "type": "object",
         "title": "Check: filetype checks based on its filename",
-        "description": "This object exists with the only purpose of being a reference of pattern checks of the given filetype of a file based on its corresponding filename (e.g. if the file is 'alignment.bam.gpg' its filetype_id shall be 'BAM' and not 'XLSX')",
+        "description": "This object exists with the only purpose of being a reference of pattern checks of the given filetype of a file based on its corresponding filename (e.g. if the file is 'alignment.bam.gpg' its filetypeId shall be 'BAM' and not 'XLSX')",
         "anyOf": [
           {
-            "title": "CEL Filename pattern-check",
+            "title": "CEL Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["CEL"] 
                 },
-                "filename": { "$ref": "#/definitions/cel-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/celFileFilenamePattern" }
             }
           },                
           {
-            "title": "TSV Filename pattern-check",
+            "title": "TSV Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["TSV"] 
                 },
-                "filename": { "$ref": "#/definitions/tsv-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/tsvFileFilenamePattern" }
             }
           },                
           {
-            "title": "ADF Filename pattern-check",
+            "title": "ADF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["ADF"] 
                 },
-                "filename": { "$ref": "#/definitions/adf-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/adfFileFilenamePattern" }
             }
           },                
           {
-            "title": "FASTQ Filename pattern-check",
+            "title": "FASTQ Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["FASTQ"] 
                 },
-                "filename": { "$ref": "#/definitions/fastq-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/fastqFileFilenamePattern" }
             }
           },                
           {
-            "title": "FASTA Filename pattern-check",
+            "title": "FASTA Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["FASTA"] 
                 },
-                "filename": { "$ref": "#/definitions/fasta-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/fastaFileFilenamePattern" }
             }
           },                
           {
-            "title": "SDRF Filename pattern-check",
+            "title": "SDRF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["SDRF"] 
                 },
-                "filename": { "$ref": "#/definitions/sdrf-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/sdrfFileFilenamePattern" }
             }
           },                
           {
-            "title": "IDF Filename pattern-check",
+            "title": "IDF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["IDF"] 
                 },
-                "filename": { "$ref": "#/definitions/idf-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/idfFileFilenamePattern" }
             }
           },                
           {
-            "title": "VCF Filename pattern-check",
+            "title": "VCF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["VCF"] 
                 },
-                "filename": { "$ref": "#/definitions/vcf-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/vcfFileFilenamePattern" }
             }
           },                
           {
-            "title": "SRA Filename pattern-check",
+            "title": "SRA Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["SRA"] 
                 },
-                "filename": { "$ref": "#/definitions/sra-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/sraFileFilenamePattern" }
             }
           },                
           {
-            "title": "SRF Filename pattern-check",
+            "title": "SRF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["SRF"] 
                 },
-                "filename": { "$ref": "#/definitions/srf-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/srfFileFilenamePattern" }
             }
           },                
           {
-            "title": "SFF Filename pattern-check",
+            "title": "SFF Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["SFF"] 
                 },
-                "filename": { "$ref": "#/definitions/sff-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/sffFileFilenamePattern" }
             }
           },                
           {
-            "title": "BAM Filename pattern-check",
+            "title": "BAM Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["BAM"] 
                 },
-                "filename": { "$ref": "#/definitions/bam-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/bamFileFilenamePattern" }
             }
           },                
           {
-            "title": "CRAM Filename pattern-check",
+            "title": "CRAM Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["CRAM"] 
                 },
-                "filename": { "$ref": "#/definitions/cram-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/cramFileFilenamePattern" }
             }
           },                
           {
-            "title": "XLSX Filename pattern-check",
+            "title": "XLSX Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["XLSX"] 
                 },
-                "filename": { "$ref": "#/definitions/xlsx-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/xlsxFileFilenamePattern" }
             }
           },                
           {
-            "title": "CSV Filename pattern-check",
+            "title": "CSV Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["CSV"] 
                 },
-                "filename": { "$ref": "#/definitions/csv-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/csvFileFilenamePattern" }
             }
           },                
           {
-            "title": "BED Filename pattern-check",
+            "title": "BED Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["BED"] 
                 },
-                "filename": { "$ref": "#/definitions/bed-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/bedFileFilenamePattern" }
             }
           },                
           {
-            "title": "IDAT Filename pattern-check",
+            "title": "IDAT Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["IDAT"] 
                 },
-                "filename": { "$ref": "#/definitions/idat-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/idatFileFilenamePattern" }
             }
           },                
           {
-            "title": "MAP Filename pattern-check",
+            "title": "MAP Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["MAP"] 
                 },
-                "filename": { "$ref": "#/definitions/map-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/mapFileFilenamePattern" }
             }
           },                
           {
-            "title": "PED Filename pattern-check",
+            "title": "PED Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["PED"] 
                 },
-                "filename": { "$ref": "#/definitions/ped-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/pedFileFilenamePattern" }
             }
           },                
           {
-            "title": "BIM Filename pattern-check",
+            "title": "BIM Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["BIM"] 
                 },
-                "filename": { "$ref": "#/definitions/bim-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/bimFileFilenamePattern" }
             }
           },                
           {
-            "title": "FAM Filename pattern-check",
+            "title": "FAM Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["FAM"] 
                 },
-                "filename": { "$ref": "#/definitions/fam-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/famFileFilenamePattern" }
             }
           },
           {
-            "title": "TXT Filename pattern-check",
+            "title": "TXT Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["TXT"] 
                 },
-                "filename": { "$ref": "#/definitions/txt-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/txtFileFilenamePattern" }
             }
           },
           {
-            "title": "EXP Filename pattern-check",
+            "title": "EXP Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["EXP"] 
                 },
-                "filename": { "$ref": "#/definitions/exp-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/expFileFilenamePattern" }
             }
           },
           {
-            "title": "GPR Filename pattern-check",
+            "title": "GPR Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["GPR"] 
                 },
-                "filename": { "$ref": "#/definitions/gpr-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/gprFileFilenamePattern" }
             }
           },
           {
-            "title": "PY Filename pattern-check",
+            "title": "PY Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["PY"] 
                 },
-                "filename": { "$ref": "#/definitions/py-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/pyFileFilenamePattern" }
             }
           },
           {
-            "title": "SH Filename pattern-check",
+            "title": "SH Filename patternCheck",
             "properties": {
                 "filetype": {
                    "enum": ["SH"] 
                 },
-                "filename": { "$ref": "#/definitions/sh-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/shFileFilenamePattern" }
             }
           },
           {
-            "title": "MD5 Filename pattern-check",
+            "title": "MD5 Filename patternCheck",
             "properties": {
                 "filetype": {
                     "enum": ["MD5"]
                 },
-                "filename": { "$ref": "#/definitions/md5-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/md5FileFilenamePattern" }
             }
           },
           {
-              "title": "HAP Filename pattern-check",
+              "title": "HAP Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["HAP"]
                   },
-                  "filename": { "$ref": "#/definitions/hap-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/hapFileFilenamePattern" }
               }
           },
           {
-              "title": "CSFASTA Filename pattern-check",
+              "title": "CSFASTA Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["CSFASTA"]
                   },
-                  "filename": { "$ref": "#/definitions/csfasta-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/csfastaFileFilenamePattern" }
               }
           },
           {
-              "title": "LOC Filename pattern-check",
+              "title": "LOC Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["LOC"]
                   },
-                  "filename": { "$ref": "#/definitions/loc-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/locFileFilenamePattern" }
               }
           },
           {
-              "title": "HTML Filename pattern-check",
+              "title": "HTML Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["HTML"]
                   },
-                  "filename": { "$ref": "#/definitions/html-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/htmlFileFilenamePattern" }
               }
           },
           {
-              "title": "HIC Filename pattern-check",
+              "title": "HIC Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["HIC"]
                   },
-                  "filename": { "$ref": "#/definitions/hic-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/hicFileFilenamePattern" }
               }
           },
           {
-              "title": "MD Filename pattern-check",
+              "title": "MD Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["MD"]
                   },
-                  "filename": { "$ref": "#/definitions/md-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/mdFileFilenamePattern" }
               }
           },
           {
-              "title": "MATLAB Filename pattern-check",
+              "title": "MATLAB Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["MATLAB"]
                   },
-                  "filename": { "$ref": "#/definitions/matlab-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/matlabFileFilenamePattern" }
               }
           },
           {
-              "title": "PERL Filename pattern-check",
+              "title": "PERL Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["PERL"]
                   },
-                  "filename": { "$ref": "#/definitions/perl-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/perlFileFilenamePattern" }
               }
           },
           {
-              "title": "TIF Filename pattern-check",
+              "title": "TIF Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["TIF"]
                   },
-                  "filename": { "$ref": "#/definitions/tif-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/tifFileFilenamePattern" }
               }
           },
           {
-              "title": "R Filename pattern-check",
+              "title": "R Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["R"]
                   },
-                  "filename": { "$ref": "#/definitions/r-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/rFileFilenamePattern" }
               }
           },
           {
-              "title": "SNP Filename pattern-check",
+              "title": "SNP Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["SNP"]
                   },
-                  "filename": { "$ref": "#/definitions/snp-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/snpFileFilenamePattern" }
               }
           },
           {
-              "title": "XML Filename pattern-check",
+              "title": "XML Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["XML"]
                   },
-                  "filename": { "$ref": "#/definitions/xml-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/xmlFileFilenamePattern" }
               }
           },
           {
-              "title": "SVG Filename pattern-check",
+              "title": "SVG Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["SVG"]
                   },
-                  "filename": { "$ref": "#/definitions/svg-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/svgFileFilenamePattern" }
               }
           },
           {
-              "title": "PNG Filename pattern-check",
+              "title": "PNG Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["PNG"]
                   },
-                  "filename": { "$ref": "#/definitions/png-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/pngFileFilenamePattern" }
               }
           },
           {
-              "title": "JPG Filename pattern-check",
+              "title": "JPG Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["JPG"]
                   },
-                  "filename": { "$ref": "#/definitions/jpg-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/jpgFileFilenamePattern" }
               }
           },
           {
-              "title": "GTC Filename pattern-check",
+              "title": "GTC Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["GTC"]
                   },
-                  "filename": { "$ref": "#/definitions/gtc-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/gtcFileFilenamePattern" }
               }
           },
           {
-              "title": "HDF5 Filename pattern-check",
+              "title": "HDF5 Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["HDF5"]
                   },
-                  "filename": { "$ref": "#/definitions/hdf5-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/hdf5FileFilenamePattern" }
               }
           },
           {
-            "title": "FAST5 Filename pattern-check",
+            "title": "FAST5 Filename patternCheck",
             "properties": {
                 "filetype": {
                     "enum": ["FAST5"]
                 },
-                "filename": { "$ref": "#/definitions/fast5-file-filename-pattern" }
+                "filename": { "$ref": "#/definitions/fast5FileFilenamePattern" }
             }
           },
           {
-              "title": "PAIR Filename pattern-check",
+              "title": "PAIR Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["PAIR"]
                   },
-                  "filename": { "$ref": "#/definitions/pair-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/pairFileFilenamePattern" }
               }
           },
           {
-              "title": "TXT Filename pattern-check",
+              "title": "TXT Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["TXT"]
                   },
-                  "filename": { "$ref": "#/definitions/txt-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/txtFileFilenamePattern" }
               }
           },
           {
-              "title": "BGI Filename pattern-check",
+              "title": "BGI Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BGI"]
                   },
-                  "filename": { "$ref": "#/definitions/bgi-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/bgiFileFilenamePattern" }
               }
           },
           {
-              "title": "BGEN Filename pattern-check",
+              "title": "BGEN Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BGEN"]
                   },
-                  "filename": { "$ref": "#/definitions/bgen-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/bgenFileFilenamePattern" }
               }
           },
           {
-              "title": "GEN Filename pattern-check",
+              "title": "GEN Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["GEN"]
                   },
-                  "filename": { "$ref": "#/definitions/gen-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/genFileFilenamePattern" }
               }
           },
           {
-              "title": "PXF Filename pattern-check",
+              "title": "PXF Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["PXF"]
                   },
-                  "filename": { "$ref": "#/definitions/pxf-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/pxfFileFilenamePattern" }
               }
           },
           {
-              "title": "LOOM Filename pattern-check",
+              "title": "LOOM Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["LOOM"]
                   },
-                  "filename": { "$ref": "#/definitions/loom-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/loomFileFilenamePattern" }
               }
           },
           {
-              "title": "BAX.H5 Filename pattern-check",
+              "title": "BAX.H5 Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BAX.H5"]
                   },
-                  "filename": { "$ref": "#/definitions/bax.h5-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/bax.h5FileFilenamePattern" }
               }
           },
           {
-              "title": "BAS.H5 Filename pattern-check",
+              "title": "BAS.H5 Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BAS.H5"]
                   },
-                  "filename": { "$ref": "#/definitions/bas.h5-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/bas.h5FileFilenamePattern" }
               }
           },
           {
-              "title": "ASM Filename pattern-check",
+              "title": "ASM Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["ASM"]
                   },
-                  "filename": { "$ref": "#/definitions/asm-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/asmFileFilenamePattern" }
               }
           },
           {
-              "title": "CSI Filename pattern-check",
+              "title": "CSI Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["CSI"]
                   },
-                  "filename": { "$ref": "#/definitions/csi-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/csiFileFilenamePattern" }
               }
           },
           {
-              "title": "TBI Filename pattern-check",
+              "title": "TBI Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["TBI"]
                   },
-                  "filename": { "$ref": "#/definitions/tbi-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/tbiFileFilenamePattern" }
               }
           },
           {
-              "title": "BCF Filename pattern-check",
+              "title": "BCF Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BCF"]
                   },
-                  "filename": { "$ref": "#/definitions/bcf-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/bcfFileFilenamePattern" }
               }
           },
           {
-              "title": "qual454 Filename pattern-check",
+              "title": "qual454 Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["qual454"]
                   },
-                  "filename": { "$ref": "#/definitions/qual454-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/qual454FileFilenamePattern" }
               }
           },
           {
-              "title": "qualsolid Filename pattern-check",
+              "title": "qualsolid Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["qualsolid"]
                   },
-                  "filename": { "$ref": "#/definitions/qualsolid-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/qualsolidFileFilenamePattern" }
               }
           },
           {
-              "title": "FASTQ-illumina Filename pattern-check",
+              "title": "FASTQ-illumina Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["FASTQ-illumina"]
                   },
-                  "filename": { "$ref": "#/definitions/fastq-illumina-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/fastqIlluminaFileFilenamePattern" }
               }
           },
           {
-              "title": "FASTQ-helicos Filename pattern-check",
+              "title": "FASTQ-helicos Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["FASTQ-helicos"]
                   },
-                  "filename": { "$ref": "#/definitions/fastq-helicos-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/fastqHelicosFileFilenamePattern" }
               }
           },
           {
-              "title": "FASTQ-sanger Filename pattern-check",
+              "title": "FASTQ-sanger Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["FASTQ-sanger"]
                   },
-                  "filename": { "$ref": "#/definitions/fastq-sanger-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/fastqSangerFileFilenamePattern" }
               }
           },
           {
-              "title": "FASTQ-solexa Filename pattern-check",
+              "title": "FASTQ-solexa Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["FASTQ-solexa"]
                   },
-                  "filename": { "$ref": "#/definitions/fastq-solexa-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/fastqSolexaFileFilenamePattern" }
               }
           },
           {
-              "title": "SAM Filename pattern-check",
+              "title": "SAM Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["SAM"]
                   },
-                  "filename": { "$ref": "#/definitions/sam-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/samFileFilenamePattern" }
               }
           },
           {
-              "title": "CRAI Filename pattern-check",
+              "title": "CRAI Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["CRAI"]
                   },
-                  "filename": { "$ref": "#/definitions/crai-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/craiFileFilenamePattern" }
               }
           },
           {
-              "title": "BAI Filename pattern-check",
+              "title": "BAI Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["BAI"]
                   },
-                  "filename": { "$ref": "#/definitions/bai-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/baiFileFilenamePattern" }
               }
           },
           {
-              "title": "MTX Filename pattern-check",
+              "title": "MTX Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["MTX"]
                   },
-                  "filename": { "$ref": "#/definitions/mtx-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/mtxFileFilenamePattern" }
               }
           },
           {
-              "title": "MEX Filename pattern-check",
+              "title": "MEX Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["MEX"]
                   },
-                  "filename": { "$ref": "#/definitions/mex-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/mexFileFilenamePattern" }
               }
           },
           {
-              "title": "GMX Filename pattern-check",
+              "title": "GMX Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["GMX"]
                   },
-                  "filename": { "$ref": "#/definitions/gmx-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/gmxFileFilenamePattern" }
               }
           },
           {
-              "title": "GMT Filename pattern-check",
+              "title": "GMT Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["GMT"]
                   },
-                  "filename": { "$ref": "#/definitions/gmt-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/gmtFileFilenamePattern" }
               }
           },
           {
-              "title": "GRP Filename pattern-check",
+              "title": "GRP Filename patternCheck",
               "properties": {
                   "filetype": {
                       "enum": ["GRP"]
                   },
-                  "filename": { "$ref": "#/definitions/grp-file-filename-pattern" }
+                  "filename": { "$ref": "#/definitions/grpFileFilenamePattern" }
               }
           }
         ]        
       },
 
-      "assay-filetypes": {
+      "assayFiletypes": {
         "type": "object",
         "title": "Check: allowed filetypes for an assay",
         "description": "This object exists with the only purpose of being a reference list of the allowed filetypes of an assay (e.g. if the filetype is 'PY', it should not be accepted as raw data). It imitates the 'filetype' property with a subset of the allowed filetypes.",
@@ -1429,703 +1429,703 @@
       }
       ,
 
-      "cel-file-filename-pattern": {
+      "celFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CEL file",
-        "meta:property_curie": "format:1638",
-        "description": "This object exists to hold the filename pattern that a 'CEL' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1638",
+        "description": "This object exists to hold the filename pattern that a 'CEL' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.cel(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.cel.gz.gpg" ]
       },
 
-      "tsv-file-filename-pattern": {
+      "tsvFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TSV file",
-        "meta:property_curie": "format:3475",
-        "description": "This object exists to hold the filename pattern that a 'TSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3475",
+        "description": "This object exists to hold the filename pattern that a 'TSV' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.tsv(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tsv.gz.gpg" ]
       },
 
-      "fastq-file-filename-pattern": {
+      "fastqFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTQ file",
-        "meta:property_curie": "format:1930",
-        "description": "This object exists to hold the filename pattern that a 'FASTQ' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1930",
+        "description": "This object exists to hold the filename pattern that a 'FASTQ' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(fastq|fq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gz.gpg" ]
       },
 
-      "fasta-file-filename-pattern": {
+      "fastaFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTA file",
-        "meta:property_curie": "format:1929",
-        "description": "This object exists to hold the filename pattern that a 'FASTA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1929",
+        "description": "This object exists to hold the filename pattern that a 'FASTA' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(fasta|fa|frn|faa|ffn|fna|seq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fasta.gz.gpg" ]
       },
 
-      "sdrf-file-filename-pattern": {
+      "sdrfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SDRF file",
-        "meta:property_curie": "NCIT:C172211",
-        "description": "This object exists to hold the filename pattern that a 'SDRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "NCIT:C172211",
+        "description": "This object exists to hold the filename pattern that a 'SDRF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(tsv|sdrf)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sdrf.gz.gpg" ]
       },
 
-      "idf-file-filename-pattern": {
+      "idfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a IDF file",
-        "meta:property_curie": "NCIT:C172212",
-        "description": "This object exists to hold the filename pattern that a 'IDF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "NCIT:C172212",
+        "description": "This object exists to hold the filename pattern that a 'IDF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(tsv|idf)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.idf.gz.gpg" ]
       },
 
-      "vcf-file-filename-pattern": {
+      "vcfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a VCF file",
-        "meta:property_curie": "format:3016",
-        "description": "This object exists to hold the filename pattern that a 'VCF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3016",
+        "description": "This object exists to hold the filename pattern that a 'VCF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.vcf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.vcf.gz.gpg" ]
       },
 
-      "sra-file-filename-pattern": {
+      "sraFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SRA file",
-        "meta:property_curie": "format:3698",
-        "description": "This object exists to hold the filename pattern that a 'SRA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3698",
+        "description": "This object exists to hold the filename pattern that a 'SRA' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.sra(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sra.gz" ]
       },
 
-      "srf-file-filename-pattern": {
+      "srfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SRF file",
-        "meta:property_curie": "format:3017",
-        "description": "This object exists to hold the filename pattern that a 'SRF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3017",
+        "description": "This object exists to hold the filename pattern that a 'SRF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.srf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.srf.gz.gpg" ]
       },
 
-      "sff-file-filename-pattern": {
+      "sffFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SFF file",
-        "meta:property_curie": "format:3284",
-        "description": "This object exists to hold the filename pattern that a 'SFF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3284",
+        "description": "This object exists to hold the filename pattern that a 'SFF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.sff(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sff.gz.gpg" ]
       },
 
-      "bam-file-filename-pattern": {
+      "bamFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BAM file",
-        "meta:property_curie": "format:2572",
-        "description": "This object exists to hold the filename pattern that a 'BAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:2572",
+        "description": "This object exists to hold the filename pattern that a 'BAM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.bam(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bam.gpg" ]
       },
 
-      "cram-file-filename-pattern": {
+      "cramFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CRAM file",
-        "meta:property_curie": "format:3462",
-        "description": "This object exists to hold the filename pattern that a 'CRAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3462",
+        "description": "This object exists to hold the filename pattern that a 'CRAM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.cram(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.cram.gpg" ]
       },
 
-      "xlsx-file-filename-pattern": {
+      "xlsxFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a  file",
-        "meta:property_curie": "format:3620",
-        "description": "This object exists to hold the filename pattern that a 'XLSX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3620",
+        "description": "This object exists to hold the filename pattern that a 'XLSX' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.xlsx(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.xlsx.tar.gpg" ]
       },
 
-      "csv-file-filename-pattern": {
+      "csvFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CSV file",
-        "meta:property_curie": "format:3752",
-        "description": "This object exists to hold the filename pattern that a 'CSV' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3752",
+        "description": "This object exists to hold the filename pattern that a 'CSV' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.csv(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.csv" ]
       },
 
-      "bed-file-filename-pattern": {
+      "bedFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BED file",
-        "meta:property_curie": "format:3003",
-        "description": "This object exists to hold the filename pattern that a 'BED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3003",
+        "description": "This object exists to hold the filename pattern that a 'BED' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.bed(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bed.gpg" ]
       },
 
-      "idat-file-filename-pattern": {
+      "idatFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a IDAT file",
-        "meta:property_curie": "format:3578",
-        "description": "This object exists to hold the filename pattern that a 'IDAT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3578",
+        "description": "This object exists to hold the filename pattern that a 'IDAT' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.idat(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.idat.zip" ]
       },
 
-      "map-file-filename-pattern": {
+      "mapFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MAP file",
-        "meta:property_curie": "format:3285",
-        "description": "This object exists to hold the filename pattern that a 'MAP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3285",
+        "description": "This object exists to hold the filename pattern that a 'MAP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.map(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.map.gpg" ]
       },
 
-      "ped-file-filename-pattern": {
+      "pedFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PED file",
-        "meta:property_curie": "format:3286",
-        "description": "This object exists to hold the filename pattern that a 'PED' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3286",
+        "description": "This object exists to hold the filename pattern that a 'PED' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(ped|tped)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.ped.gz.gpg" ]
       },
 
-      "bim-file-filename-pattern": {
+      "bimFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BIM file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'BIM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'BIM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.bim(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bim.gz.gpg" ]
       },
 
-      "fam-file-filename-pattern": {
+      "famFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FAM file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'FAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'FAM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^.+\\.(fam|tfam)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fam.gz.gpg" ]
       },
 
-      "txt-file-filename-pattern": {
+      "txtFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TXT file",
-        "meta:property_curie": "format:2330",
-        "description": "This object exists to hold the filename pattern that a 'TXT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema. It can represent multiple types of data (e.g. an ADF file or a README file)",
+        "meta:propertyCurie": "format:2330",
+        "description": "This object exists to hold the filename pattern that a 'TXT' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema. It can represent multiple types of data (e.g. an ADF file or a README file)",
         "pattern": "^[^<>:;,?\"*|/]+\\.(txt|TXT)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.txt.gz.gpg" ]
       },
 
-      "exp-file-filename-pattern": {
+      "expFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a EXP file",
-        "meta:property_curie": "format:1631",
-        "description": "This object exists to hold the filename pattern that a 'EXP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1631",
+        "description": "This object exists to hold the filename pattern that a 'EXP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(exp|EXP)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.exp.gz.gpg" ]
       },
 
-      "gpr-file-filename-pattern": {
+      "gprFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GPR file",
-        "meta:property_curie": "format:3829",
-        "description": "This object exists to hold the filename pattern that a 'GPR' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3829",
+        "description": "This object exists to hold the filename pattern that a 'GPR' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(gpr|GPR)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.gpr.gz.gpg" ]
       },
 
-      "py-file-filename-pattern": {
+      "pyFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PY file",
-        "meta:property_curie": "format:3996",
-        "description": "This object exists to hold the filename pattern that a 'PY' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3996",
+        "description": "This object exists to hold the filename pattern that a 'PY' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(py|PY|pyc|pyo|pyd|ipynb)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.py.gz.gpg" ]
       },
 
-      "sh-file-filename-pattern": {
+      "shFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SH file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'SH' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'SH' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(sh|SH)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sh.gpg" ]
       },
 
-      "adf-file-filename-pattern": {
+      "adfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a ADF (Array Design Format) file",
-        "meta:property_curie": "NCIT:C172213",
-        "description": "This object exists to hold the filename pattern that a 'ADF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "NCIT:C172213",
+        "description": "This object exists to hold the filename pattern that a 'ADF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(adf)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.adf.gz.gpg" ]
       },
 
-      "md5-file-filename-pattern": {
+      "md5FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MD5 file",
-        "meta:property_curie": "data:2190",
-        "description": "This object exists to hold the filename pattern that a 'MD5' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "data:2190",
+        "description": "This object exists to hold the filename pattern that a 'MD5' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(md5|MD5)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.md5.gz.gpg" ]
       },
 
-      "hap-file-filename-pattern": {
+      "hapFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a HAP file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'HAP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'HAP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(hap|HAP)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.hap.gz.gpg" ]
       },
 
-      "csfasta-file-filename-pattern": {
+      "csfastaFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CSFASTA file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'CSFASTA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'CSFASTA' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.csfasta(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.csfasta.gpg" ]
       },
 
-      "loc-file-filename-pattern": {
+      "locFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a LOC file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'LOC' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'LOC' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(loc|tsv)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.loc.gpg" ]
       },
 
-      "tgz-file-filename-pattern": {
+      "tgzFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TGZ file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'TGZ' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'TGZ' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.tgz(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tgz.gpg" ]
       },
 
-      "zip-file-filename-pattern": {
+      "zipFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a ZIP file",
-        "meta:property_curie": "format:3987",
-        "description": "This object exists to hold the filename pattern that a 'ZIP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3987",
+        "description": "This object exists to hold the filename pattern that a 'ZIP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.zip(\\.gpg)?$",
         "examples": [ "my_file1.zip.gpg" ]
       },
 
-      "html-file-filename-pattern": {
+      "htmlFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a HTML file",
-        "meta:property_curie": "format:2331",
-        "description": "This object exists to hold the filename pattern that a 'HTML' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:2331",
+        "description": "This object exists to hold the filename pattern that a 'HTML' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.html(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.html.gpg" ]
       },
 
-      "hic-file-filename-pattern": {
+      "hicFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a HIC file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'HIC' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'HIC' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.hic(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.hic.gpg" ]
       },
 
-      "tif-file-filename-pattern": {
+      "tifFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TIF file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'TIF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'TIF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.tif(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tif.gpg" ]
       },
 
-      "md-file-filename-pattern": {
+      "mdFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MD file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'MD' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'MD' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(md|markdown)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.md.gpg" ]
       },
 
-      "matlab-file-filename-pattern": {
+      "matlabFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MATLAB file",
-        "meta:property_curie": "format:4007",
-        "description": "This object exists to hold the filename pattern that a 'MATLAB' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:4007",
+        "description": "This object exists to hold the filename pattern that a 'MATLAB' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(M|m|MAT|mat)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.mat.gpg" ]
       },
 
-      "perl-file-filename-pattern": {
+      "perlFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PERL file",
-        "meta:property_curie": "format:3998",
-        "description": "This object exists to hold the filename pattern that a 'PERL' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3998",
+        "description": "This object exists to hold the filename pattern that a 'PERL' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(pl|perl)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.pl.gpg" ]
       },
 
-      "r-file-filename-pattern": {
+      "rFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a R file",
-        "meta:property_curie": "format:3999",
-        "description": "This object exists to hold the filename pattern that a 'R' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3999",
+        "description": "This object exists to hold the filename pattern that a 'R' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(r|R|rdata|rda)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.r.gpg" ]
       },
 
-      "tar-file-filename-pattern": {
+      "tarFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TAR file",
-        "meta:property_curie": "format:3981",
-        "description": "This object exists to hold the filename pattern that a 'TAR' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3981",
+        "description": "This object exists to hold the filename pattern that a 'TAR' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.tar(\\.(gz|zip|rar|arj|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tar.gz.gpg" ]
       },
 
-      "snp-file-filename-pattern": {
+      "snpFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SNP file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'SNP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'SNP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.snp(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.snp.zip.gpg" ]
       },
 
-      "xml-file-filename-pattern": {
+      "xmlFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a XML file",
-        "meta:property_curie": "format:2332",
-        "description": "This object exists to hold the filename pattern that a 'XML' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:2332",
+        "description": "This object exists to hold the filename pattern that a 'XML' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.xml(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.xml.gpg" ]
       },
 
-      "svg-file-filename-pattern": {
+      "svgFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SVG file",
-        "meta:property_curie": "format:3604",
-        "description": "This object exists to hold the filename pattern that a 'SVG' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3604",
+        "description": "This object exists to hold the filename pattern that a 'SVG' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.svg(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.svg.gpg" ]
       },
 
-      "png-file-filename-pattern": {
+      "pngFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PNG file",
-        "meta:property_curie": "format:3603",
-        "description": "This object exists to hold the filename pattern that a 'PNG' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3603",
+        "description": "This object exists to hold the filename pattern that a 'PNG' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.png(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.png.gpg" ]
       },
 
-      "jpg-file-filename-pattern": {
+      "jpgFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a JPG file",
-        "meta:property_curie": "format:3579",
-        "description": "This object exists to hold the filename pattern that a 'JPG' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3579",
+        "description": "This object exists to hold the filename pattern that a 'JPG' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.jpg(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.jpg.gpg" ]
       },
 
-      "gtc-file-filename-pattern": {
+      "gtcFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GTC file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'GTC' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'GTC' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.gtc(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.gtc.gpg" ]
       },
 
-      "hdf5-file-filename-pattern": {
+      "hdf5FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a HDF5 file",
-        "meta:property_curie": "format:3590",
-        "description": "This object exists to hold the filename pattern that a 'HDF5' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3590",
+        "description": "This object exists to hold the filename pattern that a 'HDF5' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(h5|hdf5)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.h5.gpg" ]
       },
 
-      "fast5-file-filename-pattern": {
+      "fast5FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FAST5 file",
-        "meta:property_curie": "format:3590",
-        "description": "This object exists to hold the filename pattern that a 'FAST5' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3590",
+        "description": "This object exists to hold the filename pattern that a 'FAST5' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.fast5(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fast5.gpg" ]
       },
 
-      "pair-file-filename-pattern": {
+      "pairFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PAIR file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'PAIR' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'PAIR' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.pair(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.pair.gpg" ]
       },
 
-      "bgi-file-filename-pattern": {
+      "bgiFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BGI file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'BGI' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'BGI' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.bgi(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bgi.gpg" ]
       },
 
-      "bgen-file-filename-pattern": {
+      "bgenFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BGEN file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'BGEN' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'BGEN' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.bgen(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bgen.gpg" ]
       },
 
-      "gen-file-filename-pattern": {
+      "genFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GEN file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'GEN' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'GEN' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.gen(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.gen.gpg" ]
       },
 
-      "pxf-file-filename-pattern": {
+      "pxfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a PXF file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'PXF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'PXF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(json|yaml)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.json.gpg" ]
       },
 
-      "loom-file-filename-pattern": {
+      "loomFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a LOOM file",
-        "meta:property_curie": "format:3913",
-        "description": "This object exists to hold the filename pattern that a 'LOOM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3913",
+        "description": "This object exists to hold the filename pattern that a 'LOOM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.loom(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.loom.gpg" ]
       },
 
-      "bax.h5-file-filename-pattern": {
+      "bax.h5FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BAX.H5 file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'BAX.H5' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'BAX.H5' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(bax\\.h5|h5)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bax.h5.gpg" ]
       },
 
-      "bas.h5-file-filename-pattern": {
+      "bas.h5FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BAS.H5 file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'BAS.H5' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'BAS.H5' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(bas\\.h5|h5)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bas.h5.gpg" ]
       },
 
-      "asm-file-filename-pattern": {
+      "asmFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a ASM file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'ASM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'ASM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.asm(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.asm.gpg" ]
       },
 
-      "csi-file-filename-pattern": {
+      "csiFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CSI file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'CSI' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'CSI' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.csi(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.csi.gpg" ]
       },
 
-      "tbi-file-filename-pattern": {
+      "tbiFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a TBI file",
-        "meta:property_curie": "format:3700",
-        "description": "This object exists to hold the filename pattern that a 'TBI' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3700",
+        "description": "This object exists to hold the filename pattern that a 'TBI' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.tbi(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.tbi.gpg" ]
       },
 
-      "bcf-file-filename-pattern": {
+      "bcfFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BCF file",
-        "meta:property_curie": "format:3020",
-        "description": "This object exists to hold the filename pattern that a 'BCF' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3020",
+        "description": "This object exists to hold the filename pattern that a 'BCF' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.bcf(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bcf.gpg" ]
       },
 
-      "qual454-file-filename-pattern": {
+      "qual454FileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a QUAL454 file",
-        "meta:property_curie": "format:3611",
-        "description": "This object exists to hold the filename pattern that a 'QUAL454' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3611",
+        "description": "This object exists to hold the filename pattern that a 'QUAL454' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(qual454|qual)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.qual.gpg" ]
       },
 
-      "qualsolid-file-filename-pattern": {
+      "qualsolidFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a QUALSOLID file",
-        "meta:property_curie": "format:3610",
-        "description": "This object exists to hold the filename pattern that a 'QUALSOLID' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3610",
+        "description": "This object exists to hold the filename pattern that a 'QUALSOLID' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(qualsolid|qual)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.qualsolid.gpg" ]
       },
 
-      "fastq-illumina-file-filename-pattern": {
+      "fastqIlluminaFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTQ-ILLUMINA file",
-        "meta:property_curie": "format:1931",
-        "description": "This object exists to hold the filename pattern that a 'FASTQ-ILLUMINA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1931",
+        "description": "This object exists to hold the filename pattern that a 'FASTQ-ILLUMINA' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(fastq|fq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gpg" ]
       },
 
-      "fastq-helicos-file-filename-pattern": {
+      "fastqHelicosFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTQ-HELICOS file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'FASTQ-HELICOS' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'FASTQ-HELICOS' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(fastq|fq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gpg" ]
       },
 
-      "fastq-sanger-file-filename-pattern": {
+      "fastqSangerFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTQ-SANGER file",
-        "meta:property_curie": "format:1932",
-        "description": "This object exists to hold the filename pattern that a 'FASTQ-SANGER' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1932",
+        "description": "This object exists to hold the filename pattern that a 'FASTQ-SANGER' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(fastq|fq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gpg" ]
       },
 
-      "fastq-solexa-file-filename-pattern": {
+      "fastqSolexaFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a FASTQ-SOLEXA file",
-        "meta:property_curie": "format:1933",
-        "description": "This object exists to hold the filename pattern that a 'FASTQ-SOLEXA' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:1933",
+        "description": "This object exists to hold the filename pattern that a 'FASTQ-SOLEXA' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.(fastq|fq)(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.fastq.gpg" ]
       },
 
-      "sam-file-filename-pattern": {
+      "samFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a SAM file",
-        "meta:property_curie": "format:2573",
-        "description": "This object exists to hold the filename pattern that a 'SAM' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:2573",
+        "description": "This object exists to hold the filename pattern that a 'SAM' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.sam(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.sam.gpg" ]
       },
 
-      "crai-file-filename-pattern": {
+      "craiFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a CRAI file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'CRAI' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'CRAI' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.crai(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.crai.gpg" ]
       },
 
-      "bai-file-filename-pattern": {
+      "baiFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a BAI file",
-        "meta:property_curie": "format:3327",
-        "description": "This object exists to hold the filename pattern that a 'BAI' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3327",
+        "description": "This object exists to hold the filename pattern that a 'BAI' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.bai(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.bai.gpg" ]
       },
 
-      "mtx-file-filename-pattern": {
+      "mtxFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MTX file",
-        "meta:property_curie": "format:3916",
-        "description": "This object exists to hold the filename pattern that a 'MTX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "format:3916",
+        "description": "This object exists to hold the filename pattern that a 'MTX' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.mtx(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.mtx.gpg" ]
       },
 
-      "mex-file-filename-pattern": {
+      "mexFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a MEX file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'MEX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'MEX' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.mex(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.mex.gpg" ]
       },
 
-      "gmx-file-filename-pattern": {
+      "gmxFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GMX file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'GMX' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'GMX' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.gmx(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.gmx.gpg" ]
       },
 
-      "gmt-file-filename-pattern": {
+      "gmtFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GMT file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'GMT' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'GMT' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.gmt(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.gmt.gpg" ]
       },
 
-      "grp-file-filename-pattern": {
+      "grpFileFilenamePattern": {
         "type": "string",
         "title": "Filename pattern of a GRP file",
-        "meta:property_curie": "",
-        "description": "This object exists to hold the filename pattern that a 'GRP' filetype_id would have, for it to be referenced elsewhere within this (or other) JSON schema.",
+        "meta:propertyCurie": "",
+        "description": "This object exists to hold the filename pattern that a 'GRP' filetypeId would have, for it to be referenced elsewhere within this (or other) JSON schema.",
         "pattern": "^[^<>:;,?\"*|/]+\\.grp(\\.(gz|zip|rar|arj|tar|7z|bz2))?(\\.gpg)?$",
         "examples": [ "my_file1.grp.gpg" ]
       },
 
-      "object_external_accession": {
+      "objectExternalAccession": {
         "type": "object",
         "title": "Object of external accession of the object",
         "description": "External accession node containing the object accession (i.e. unique identifier -  each following their respective formats) assigned by other archives (e.g. biosample, ena, ensembl...) and an optional label to add context to the reference.",
         "additionalProperties": false,
         "properties": {
-          "external_accession_curie": {
+          "externalAccessionCurie": {
             "type": "string",
             "title": "CURIE of the external accession",
             "description": "Unique identifier of an external, to EGA, object. It shall follow CURIE format (``prefix``:``accession``): prefix assigned to the archive (e.g. biosample - search for yours at identifiers.org) and the unique accession of the object (e.g. SAMEA7616999).",
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "examples": [ "biosample:SAMEA7616999", "arrayexpress:E-MEXP-1712", "biostudies:S-EPMC3314381", "pubmed:30962759"]
           },
-          "accession_reference": {
+          "accessionReference": {
             "type": "string",
             "title": "Reference of the external accession",
             "description": "Full or partial URL/URI of the external accession, for systems to resolve it.",
             "allOf": [
               {
                 "title": "General pattern of a URL/URI",
-                "$ref": "./EGA.common-definitions.json#/definitions/url-uri-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/urlUriPattern"
               }
             ],
             "examples": [ "https://www.ebi.ac.uk/biosamples/samples/SAMN11716999", "https://pubmed.ncbi.nlm.nih.gov/19491253", "https://identifiers.org/arrayexpress:E-MEXP-1712", "https://www.ebi.ac.uk/arrayexpress/experiments/E-MEXP-1712/" ]
           },
-          "accession_label": {
+          "accessionLabel": {
             "type": ["string", "number"],
             "title": "Label of the external accession",
             "description": "Label (e.g. 'taken from biosample temporarily') of the external accession, used to add extra information to the identifier.",
@@ -2135,39 +2135,39 @@
         "anyOf": [
           {
             "title": "Either the CURIE is needed",
-            "required": ["external_accession_curie"]
+            "required": ["externalAccessionCurie"]
           },
           {
             "title": "Or the reference is needed",
-            "required": ["accession_reference"]
+            "required": ["accessionReference"]
           }
         ]
       },
 
-      "sample-label-association": {
+      "sampleLabel-association": {
         "type": "object",
         "title": "Repeatable Sample-label node",
-        "description": "The base node of a label-sample association. One form of basic identification of the sample (inherited from object_core_id - e.g. either the center name and alias or the accession) is required, as well as the label per se.",
-        "required": ["label", "object_id"],
+        "description": "The base node of a label-sample association. One form of basic identification of the sample (inherited from objectCoreId - e.g. either the center name and alias or the accession) is required, as well as the label per se.",
+        "required": ["label", "objectId"],
         "additionalProperties": false,
         "properties": {
           "label": { 
             "title": "Labelling dye used with the sample",
-            "$ref": "./EGA.common-definitions.json#/definitions/array_label" 
+            "$ref": "./EGA.common-definitions.json#/definitions/arrayLabel" 
           },
-          "object_id": {
+          "objectId": {
             "type": "object",
             "title": "Object's IDs block",
             "allOf": [
               {
-                "title": "Inherited object_core_id object",
-                "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+                "title": "Inherited objectCoreId object",
+                "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
               },
               {
                 "title": "Check that sample EGA ID (EGAN) pattern is correct",
                 "properties": {
-                  "ega_accession": {
-                    "$ref": "./EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
+                  "egaAccession": {
+                    "$ref": "./EGA.common-definitions.json#/definitions/EGASampleIdPattern"
                   }
                 }
               }
@@ -2176,29 +2176,29 @@
         }
       },
 
-      "one-relationship-end": {
+      "oneRelationshipEnd": {
         "type": "object",
         "title": "Relationship's object (either source or target)",
         "description": "Node containing metadata (identifiers and the type of reference) of one of the ends of the relationship, whether it is the source or the target of the relationship.",
         "additionalProperties": false,
-        "required": ["object_id", "object_type"],
+        "required": ["objectId", "objectType"],
         "properties": {
-          "object_id": {
+          "objectId": {
             "type": "object",
             "title": "Relationship's object's IDs block",
-            "description": "Node containing the main identifiers of the relationship's object (e.g. alias, center_name...), inherited from the common definitions (#/definitions/object_core_id).",
+            "description": "Node containing the main identifiers of the relationship's object (e.g. alias, centerName...), inherited from the common definitions (#/definitions/objectCoreId).",
             "allOf": [
               { 
-                "title": "Inherited object_core_id object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/object_core_id" 
+                "title": "Inherited objectCoreId object", 
+                "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId" 
               }
             ]
           },
-          "object_type": {
+          "objectType": {
             "type": "string",
             "title": "Type of the relationship's object",
-            "description": "Type of the relationship's object, chosen from a list of CV (e.g. experiment, dataset, external_URL...). Both the source or target types can be: (1) the object tag of one of EGA's object (e.g. file, sample...); (2) an 'external_accession'; (3) or an 'external_URL'. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema) proposing its addition.",
-            "enum": ["experiment", "study", "sample", "individual", "submission", "assay", "dataset", "analysis", "policy", "DAC", "protocol", "external_accession", "external_URL"],
+            "description": "Type of the relationship's object, chosen from a list of CV (e.g. experiment, dataset, externalURL...). Both the source or target types can be: (1) the object tag of one of EGA's object (e.g. file, sample...); (2) an 'externalAccession'; (3) or an 'externalURL'. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema) proposing its addition.",
+            "enum": ["experiment", "study", "sample", "individual", "submission", "assay", "dataset", "analysis", "policy", "DAC", "protocol", "externalAccession", "externalURL"],
             "meta:enum": {
               "experiment": "Contains information about the experimental design of the sequencing",
               "study": "Information about the study",
@@ -2211,21 +2211,21 @@
               "policy": "Contains information related to the Data Access Agreement (DAA) the dataset is subject to",
               "DAC": "Contains information about the Data Access Committee (DAC)",
               "protocol": "Contains information about a planned process.",
-              "external_accession": "An external accession among the ones Entrez (NCBI's text search) contemplates (search for the terms here: https://www.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?)",
-              "external_URL": "An external URL resource, of any type"
+              "externalAccession": "An external accession among the ones Entrez (NCBI's text search) contemplates (search for the terms here: https://www.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi?)",
+              "externalURL": "An external URL resource, of any type"
             },
             "examples": [ "sample" ]
           }
         },
         "allOf": [
           { 
-            "title": "Check for object_id and object_type to match",
-            "$ref": "./EGA.common-definitions.json#/definitions/object-id-and-object-type-check" 
+            "title": "Check for objectId and objectType to match",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectIdAndObjectTypeCheck" 
           }
         ]        
       },
 
-      "subject_id": {
+      "subjectId": {
         "type": "string",
         "title": "Subject ID",
         "description": "A unique identifier (e.g. 'Donor-10031') for the subject the sample derives from, providing context for the sample to be better understood through its provenance. It **shall not** contain personal sensitive data, since it will be publicly displayed for queries and searches.",
@@ -2233,10 +2233,10 @@
         "examples": [ "Donor-10031", "ID001", "9001", "AX_Dli" ]
       },
 
-      "biological_sex": {
+      "biologicalSex": {
         "type": "string",
         "title": "Biological sex of the individual",
-        "meta:property_curie": "PATO:0000047",
+        "meta:propertyCurie": "PATO:0000047",
         "description": "An organismal quality inhering in a bearer by virtue of the bearer's physical expression of sexual characteristics. In other words, the trait that determines the individual's (from which the sample derives) reproductive function: mainly male or female. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
         "enum": [ "male", "female", "hermaphrodite", "pseudohermaphrodite","unknown" ],
         "meta:enum": { 
@@ -2249,21 +2249,21 @@
         "examples": [ "male" ]
       },
 
-      "experimental_condition_descriptor": {
+      "experimentalConditionDescriptor": {
         "type": "object",
         "title": "Experimental condition",
-        "meta:property_curie": "XCO:0000000",
+        "meta:propertyCurie": "XCO:0000000",
         "description": "A state of being, an external or environmental factor or a treatment observed or administered prior to or concurrent with an investigative procedure such as an assessment of a morphological or physiological state or property in a single individual or sample or in a group of individuals or samples, especially a state, factor or treatment which has the potential to influence the outcome of such an assessment. We highly recommend the usage of ontologies to describe experimental conditions (search at 'https://www.ebi.ac.uk/ols/ontologies/efo').",
         "additionalProperties": false,
-        "required": ["experimental_condition_term"],
+        "required": ["experimentalConditionTerm"],
         "properties": {
-          "experimental_condition_term": {
+          "experimentalConditionTerm": {
             "type": "string",
             "title": "Experimental condition term",
             "description": "Term that specifies the experimental condition (e.g. 'fibroadenoma').",
             "examples": [ "control", "fibroadenoma", "osteonecrosis" ]
           },
-          "experimental_condition_curie": {
+          "experimentalConditionCurie": {
             "type": "string",
             "title": "Experimental condition curie",
             "description": "Curie (i.e. ontologised term - e.g. 'EFO:0001461') of the experimental condition. Search for the ontologized term at the [Ontology Lookup Service (OLS)](https://www.ebi.ac.uk/ols/index).",
@@ -2271,11 +2271,11 @@
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ]
           },
-          "experimental_condition_description": {
+          "experimentalConditionDescription": {
             "type": "string",
             "title": "Experimental condition description",
             "description": "Broad description of the experimental condition, providing further details and context over the ontologised term.",
@@ -2288,22 +2288,22 @@
         }
       },
 
-      "organism_descriptor": {
+      "organismDescriptor": {
         "type": "object",
         "title": "Organism [OBI:0100026] descriptor block",
         "description": "This property describes the material entity the sample consists in. That is, an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs. This node is of special interest in case the provenance of the sample is not human (e.g. microbiota taken from a donor). Unless stated otherwise, given the nature of the EGA, it is expected to be of human provenance by default.",
         "additionalProperties": false,
-        "required": ["taxon_id_curie"],
+        "required": ["taxonIdCurie"],
         "properties": {
-          "taxon_id_curie": {
+          "taxonIdCurie": {
             "type": "string",
             "title": "NCBI Taxon identifier",
-            "meta:property_curie": "APOLLO_SV:00000203",
+            "meta:propertyCurie": "APOLLO_SV:00000203",
             "description": "Taxonomy Identifier (e.g. 'NCBITaxon:9606' for humans) curated by the NCBI Taxonomy (search for organisms here: https://www.ncbi.nlm.nih.gov/taxonomy; or use the OLS: https://www.ebi.ac.uk/ols/ontologies/ncbitaxon). You can find further details at 'https://www.uniprot.org/help/taxonomic_identifier'. This is appropriate for individual organisms and some environmental samples.",
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "graphRestriction":  {
@@ -2315,70 +2315,70 @@
             },
             "examples": [ "NCBITaxon:9606", "NCBITaxon:155900", "NCBITaxon:408170", "NCBITaxon:447426" ]
           },
-          "scientific_name": {
+          "scientificName": {
             "type": "string",
             "title": "Biologic entity classification scientific name",
-            "meta:property_curie": "NCIT:C43459",
+            "meta:propertyCurie": "NCIT:C43459",
             "description": "The name applied to a plant, animal, or other organism, according to the Codes of Nomenclature, consisting of a Genus and species (e.g. 'homo sapiens').",
             "minLength": 1,
             "examples": [ "homo sapiens", "uncultured organism", "human gut metagenome", "human oral metagenome" ]
           },
-          "common_name": {
+          "commonName": {
             "type": "string",
             "title": "Biologic entity classification common name",
-            "meta:property_curie": "NCIT:C164690",
+            "meta:propertyCurie": "NCIT:C164690",
             "description": "Common name (e.g. 'human') used to designate a plant, animal or other organism, as opposed to the scientific name.",
             "examples": [ "human"]
           }
         }
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "type": "object",
         "title": "Schema descriptor",
         "description": "This node is intended to be used to describe the schemas and standards that a JSON document was based on. For instance, if a sample.json document was created to be validated against EGA.sample.json schema version 1.0.0, such information should be reflected in this block. This way, both a human and a machine can interpret and validate the JSON document efficiently, without the need of guessing versions.",
         "additionalProperties": false,
-        "required": ["object_type", "described_by_schema_uri", "object_schema_version", "common_schema_version"],
+        "required": ["objectType", "describedBySchemaUri", "objectSchemaVersion", "commonSchemaVersion"],
         "properties": {
-          "object_type": {
+          "objectType": {
             "type": "string",
             "title": "Type of the object",
             "description": "Type of the object (e.g. 'sample') the JSON document describes.",
             "enum": [ "experiment", "study", "sample", "individual", "submission", "assay", "dataset", "analysis", "policy", "DAC", "protocol", "object-set" ]
           },
-          "described_by_schema_uri": {
+          "describedBySchemaUri": {
             "type": "string",
             "title": "URI of the schema",
             "description": "URI of the schema (e.g. 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json') that describes the JSON document (e.g. 'my_sample.json')",
             "pattern": "^https://github\\.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA\\..+\\.json$",
             "examples": ["https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json"]
           },
-          "object_schema_version": {
+          "objectSchemaVersion": {
             "type": "string",
             "title": "Version of the object's schema",
             "description": "The version of the object's schema, the one specific for the object the JSON document corresponds to (e.g. 'EGA.sample.json'), not the common definitions schema's version (i.e. 'EGA.common-definitions.json').",
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/semanticVersioningPattern"
               }
             ]
           },
-          "common_schema_version": {
+          "commonSchemaVersion": {
             "type": "string",
             "title": "Version of the common definition's schema",
             "description": "The version of the common definition's schema, the one containing all shared definitions (i.e. 'EGA.common-definitions.json'), not the one specific to the object described by the JSON document (e.g. 'EGA.sample.json').",
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/semantic-versioning-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/semanticVersioningPattern"
               }
             ]
           }
         }
       },
 
-      "semantic-versioning-pattern": {
+      "semanticVersioningPattern": {
         "type": "string",
         "title": "Semantic versioning pattern",
         "description": "This object exists to hold the pattern that semantic versioning has, for it to be referenced elsewhere within this (or other) JSON schema. For further details about semantic versioning check 'https://semver.org/'",
@@ -2386,35 +2386,35 @@
         "examples": [ "2.5.1" ]
       },
       
-      "contact_details": {
+      "contactDetails": {
         "type": "object",
         "title": "Contact details",
         "description": "An object to contain the required metadata to identify and reach an individual or institution. Used, for instance, to list who needs to be informed (1) in case of a erroneous submission (2) or in case access to a dataset is requested by a user.",
         "additionalProperties": false,
-        "required": ["email_address"],
+        "required": ["emailAddress"],
         "properties": {
-          "individual_full_name": {
+          "individualFullName": {
             "type": "string",
             "title": "Full name of an individual",
             "description": "A full set of all personal names by which an individual is known and that can be recited as a word-group, with the understanding that, taken together, they all relate to that one individual. In case there are several, separate them with semicolons (;).",
             "minLength": 1,
             "examples": [ "Wayne Jr., Bruce" ]
           },
-          "institution_name": {
+          "institutionName": {
             "type": "string",
             "title": "Institution name",
             "description": "The full name of an institution the contact belongs to. In case there are several, separate them with semicolons (;).",
             "minLength": 1,
             "examples": [ "European Genome-phenome Archive (EGA)" ]
           },
-          "email_address": {
+          "emailAddress": {
             "type": "string",
             "title": "Email address",
             "description": "Current email address that would be used in case the contact needs to be reached. Its expected format is of a local-part (e.g. 'myname'), followed by an 'at' sign (i.e. '@') and the domain of the address (e.g. 'gmail.com' or 'ebi.ac.uk').",
             "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
             "examples": [ "myname@ebi.ac.uk" ]
           },
-          "phone_number": {
+          "phoneNumber": {
             "type": "string",
             "title": "Phone number",
             "description": "Current phone number that would be used in case the contact needs to be reached. Theoretically would only be used in case the email address was not provided, does not exist or is unresponsive.",
@@ -2425,19 +2425,19 @@
         "anyOf": [
           { 
             "title": "Either the individual's name is required.",
-            "required": ["individual_full_name"]
+            "required": ["individualFullName"]
           },
           {
             "title": "Or the institution's name is required.",
-            "required": ["institution_name"]
+            "required": ["institutionName"]
           }
         ]        
       },
 
-      "study-design-keywords": {
+      "studyDesignKeywords": {
         "type": "string",
         "title": "Enumeration of design keywords",
-        "meta:property_curie": "EFO:0001426",
+        "meta:propertyCurie": "EFO:0001426",
         "description": "An object containing the enumeration of multiple study-design keywords, to be inherited at their respective nodes. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
         "enum": ["RNA stability design", "binding site identification design", "case control design", "cell component comparison design", "cell cycle design", "cell type comparison design", "cellular modification design", "clinical history design", "compound treatment design", "cross sectional design", "development or differentiation design", "disease state design", "dose response design", "twin design", "genetic modification design", "genotype design", "growth condition design", "imprinting design", "injury design", "innate behavior design", "organism part comparison design", "organism status design", "pathogenicity design", "population based design", "sex design", "species design", "stimulus or stress design", "strain or line design", "time series design", "family based design", "genotyping design", "mobile element identification design", "operon identification design", "secreted protein identification design", "translational bias design", "transposable element identification design", "hardware variation design", "normalization testing design", "operator variation design", "optimization design", "quality control testing design", "reference design", "replicate design", "software variation design", "validation by real time PCR design", "validation by reverse transcription PCR design"],
         "meta:enum": {
@@ -2491,19 +2491,19 @@
         "examples": [ "RNA stability design" ]
       },
 
-      "locus_identifier": {
+      "locusIdentifier": {
         "type": "object",
         "title": "Locus identifier",
         "description": "Node to unambiguously identify loci [OGI:0000022]: the unique chromosomal location defining the position of an individual gene or DNA sequence. This node shall be used to precisely define: (1) the organism of said locus; (2) the gene and other genomic feature references in other accessions; (3) the genomic sequence per se, including its assembly and position. These details, in different combinations, shall allow identification of any genomic feature, such as SNPs (e.g. coordinates of a variant) or genes (e.g. PT53).",
-        "required": ["organism_descriptor", "loci_descriptor"],
+        "required": ["organismDescriptor", "lociDescriptor"],
         "additionalProperties": false,
         "properties": {
-          "organism_descriptor": {
+          "organismDescriptor": {
             "title": "Organism descriptor",
             "description": "Node to identify the specific organism the locus belongs to.",
-            "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
           },
-          "loci_descriptor": {
+          "lociDescriptor": {
             "type": "array",
             "title": "Loci context array",
             "description": "Array of locus context items. Multiple loci can be described in the array if the organism remains the same.",
@@ -2515,22 +2515,22 @@
               "title": "Locus context item",
               "description": "Node providing the context of the locus: its sequence, coordinates, encompassed genes...",
               "properties": {
-                "gene_descriptor": {
+                "geneDescriptor": {
                   "title": "Gene descriptor",
                   "description": "Node to identify the gene of the locus of interest.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/gene_descriptor"
+                  "$ref": "./EGA.common-definitions.json#/definitions/geneDescriptor"
                 },
-                "genomic_sequence_descriptor": {
+                "genomicSequenceDescriptor": {
                   "title": "Genomic sequence descriptor",
                   "description": "Node to describe the sequence per se, instead of referencing it.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/genomic_sequence_descriptor"
+                  "$ref": "./EGA.common-definitions.json#/definitions/genomicSequenceDescriptor"
                 },
-                "locus_external_reference": {
+                "locusExternalReference": {
                   "title": "External reference of the locus",
-                  "description": "If the locus can not be identified by a gene (if so, use 'gene_descriptor'), and it is well represented (i.e. uniquely identifiable and with comprehensive detail) in another resource that is accessible and persistent, one can reference it here instead of providing all their details. In other words, one can reference here ways to access the locus information that is accessible elsewhere. For example miRNA 'MI0039740' (mirbase:MI0039740) that lacks a gene descriptor.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/object_external_accession"
+                  "description": "If the locus can not be identified by a gene (if so, use 'geneDescriptor'), and it is well represented (i.e. uniquely identifiable and with comprehensive detail) in another resource that is accessible and persistent, one can reference it here instead of providing all their details. In other words, one can reference here ways to access the locus information that is accessible elsewhere. For example miRNA 'MI0039740' (mirbase:MI0039740) that lacks a gene descriptor.",
+                  "$ref": "./EGA.common-definitions.json#/definitions/objectExternalAccession"
                 },
-                "locus_additional_description": {
+                "locusAdditionalDescription": {
                   "type": "string",
                   "title": "Additional description of the locus",
                   "description": "Optional free-text description of the locus to add any additional context.",
@@ -2541,15 +2541,15 @@
               "anyOf": [
                 {
                   "title": "Either the gene description is given",
-                  "required": ["gene_descriptor"]
+                  "required": ["geneDescriptor"]
                 },
                 {
                   "title": "Or the genomic sequence context",
-                  "required": ["genomic_sequence_descriptor"]
+                  "required": ["genomicSequenceDescriptor"]
                 },
                 {
                   "title": "Or an external reference to the locus context",
-                  "required": ["locus_external_reference"]
+                  "required": ["locusExternalReference"]
                 }
               ]
             }            
@@ -2557,52 +2557,52 @@
         }
       },
 
-      "gene_descriptor": {
+      "geneDescriptor": {
         "type": "object",
         "title": "Gene descriptor",
         "description": "Node to uniquely identify a gene [SO:0000704]: a region (or regions) that includes all of the sequence elements necessary to encode a functional transcript. A gene may include regulatory regions, transcribed regions and/or other functional sequence regions. For human genes, the standard is to use nomenclature provided by the HUGO Gene Nomenclature Committee (HGNC).",
-        "required": ["gene_id_curie"],
+        "required": ["geneIdCurie"],
         "additionalProperties": false,
         "properties": {
-          "gene_symbol": {
+          "geneSymbol": {
             "type": "string",
             "title": "Gene Symbol",
-            "meta:property_curie": "data:1026",
+            "meta:propertyCurie": "data:1026",
             "description": "The official gene symbol. It is typically derived from the gene name. This optional field exists to provide the common identifier of the gene. There are several resources to search for a gene of interest, although we recommend [NCBI's service](https://www.ncbi.nlm.nih.gov/gene). For example: (1) in the case of human genes, the symbol follows [HGNC](https://www.genenames.org/)'s nomenclature; (2) while in the case of mice genes they are provided by [MGI](http://www.informatics.jax.org/).",
             "minLength": 1,
             "examples": ["TAF1", "TP53", "BRAF", "16S"]
           },
-          "gene_id_curie": {
+          "geneIdCurie": {
             "type": "string",
             "title": "Gene CURIE ID",
-            "meta:property_curie": "data:2295",
+            "meta:propertyCurie": "data:2295",
             "description": "A unique (and typically persistent) identifier of a gene in a database, that is (typically) different to the gene name/symbol (e.g. HGNC:11535 for gene TAF1). The identifier has to follow CURIE format. Additionally, there are 2 types of allowed databases to reference: NCBIGene and HGNC. Other archives' accessions (e.g. ensembl:ENSDARG00000035330) can be cross referenced with NCBIGene to obtain its gene ID (e.g. ncbigene:555452).",            
             "allOf": [
               {
                 "title": "General pattern of a CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "oneOf": [
               {
                 "title": "NCBI Gene pattern (e.g. 'NCBIGene:100010')",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_ncbi_gene_identifier_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieNcbiGeneIdentifierPattern"
               },
               {
                 "title": "NCBI Gene pattern (e.g. 'NCBIGene:100010')",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_hgnc_identifier_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieHgncIdentifierPattern"
               }
             ],
             "examples": ["HGNC:11535", "hgnc:11998", "HGNC:1097", "ncbigene:100010", "ncbigene:6872"]
           },
-          "gene_description": {
+          "geneDescription": {
             "type": "string",
             "title": "Description of the gene",
-            "description": "Free-text description of the gene, only to be used to provide additional context that would otherwise be impossible to add encoded in the schema. In other words, kindly refrain from providing alternative gene symbols in the description if they are not added likewise in the 'alternate_gene_symbols' property.",
+            "description": "Free-text description of the gene, only to be used to provide additional context that would otherwise be impossible to add encoded in the schema. In other words, kindly refrain from providing alternative gene symbols in the description if they are not added likewise in the 'alternateGeneSymbols' property.",
             "minLength": 1,
             "examples": [ "In the used cells, locus of gene ... was modified at positions +23, where thymine was transitioned to cytosine (T-C)..." ]
           },
-          "alternate_gene_ids": {
+          "alternateGeneIds": {
             "type": "array",
             "title": "Alternate gene IDs",
             "description": "Array of alternate identifiers for this gene. For example, Ensemble identifiers for genes and its transcripts.",
@@ -2612,17 +2612,17 @@
             "items": {
               "type": "string",
               "title": "Alternate gene ID",
-              "meta:property_curie": "data:2295",
+              "meta:propertyCurie": "data:2295",
               "allOf": [
                 {
                   "title": "General pattern of a CURIE",
-                  "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                  "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
                 }
               ],
               "examples": ["OMIM:600296", "ensembl:ENST00000423759.6", "ucsc:uc003ldc.6"]
             }
           },
-          "alternate_gene_symbols": {
+          "alternateGeneSymbols": {
             "type": "array",
             "title": "Alternate gene symbols",
             "description": "Array of alternate gene sumbols. This field can be used to provide any other alternate gene symbol to refer to the gene, including previously approved gene symbols. There are several resources to search for a gene of interest, although we recommend [NCBI's service](https://www.ncbi.nlm.nih.gov/gene). For example: (1) in the case of human genes, the symbol follows [HGNC](https://www.genenames.org/)'s nomenclature; (2) while in the case of mice genes they are provided by [MGI](http://www.informatics.jax.org/).",
@@ -2632,12 +2632,12 @@
             "items": {
               "type": "string",
               "title": "Alternate gene symbol",
-              "meta:property_curie": "data:1026",
+              "meta:propertyCurie": "data:1026",
               "minLength": 1,
               "examples": ["SUP45L1", "eRF1", "RF1", "ERF1"]
             }
           },
-          "gene_external_references": {
+          "geneExternalReferences": {
             "type": "array",
             "title": "Related (not equivalent) gene IDs",
             "description": "Array of related identifiers. This field can be used to provide identifiers to alternative resources representing related, but not equivalent concepts, for example gene paralog, analog or ortholog IDs.",
@@ -2647,11 +2647,11 @@
             "items": {
               "type": "string",
               "title": "Related gene ID",
-              "meta:property_curie": "data:2295",
+              "meta:propertyCurie": "data:2295",
               "allOf": [
                 {
                   "title": "General pattern of a CURIE",
-                  "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                  "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
                 }
               ],
               "examples": ["VGNC:97422", "MGI:2385071", "RGD:1305712"]
@@ -2660,49 +2660,49 @@
         }
       },
 
-      "ncbi_assembly_descriptor": {
+      "ncbiAssemblyDescriptor": {
         "type": "object",
         "title": "NCBI's Assembly descriptor",
-        "meta:property_curie": "topic:0196",
+        "meta:propertyCurie": "topic:0196",
         "description": "Node describing a sequence assembly referenced in [NCBI's Assembly database](https://www.ncbi.nlm.nih.gov/assembly). Assembly is a database providing information on the structure of assembled genomes, assembly names and other meta-data, statistical reports, and links to genomic sequence data. An assembly is defined as the set of chromosomes, unlocalized and unplaced (sometimes called 'random') and alternate sequences used to represent an organism's genome. Assemblies are constructed from 1 or more assembly units.",
         "additionalProperties": false,
         "properties": {
-          "assembly_name": {
+          "assemblyName": {
             "type": "string",
             "title": "Assembly common name",
-            "meta:property_curie": "OBI:0001948",
+            "meta:propertyCurie": "OBI:0001948",
             "description": "A free-text common name (e.g. 'GRCh38') that is used to denote the sequence assembly.",
             "minLength": 1,
             "examples": [ "GRCh38.p14", "GRCh38", "GRCh37.p13", "GRCh37" ]
           },
-          "ncbi_assembly_accession": {
+          "ncbiAssemblyAccession": {
             "type": "string",
             "title": "NCBI Assembly accession",
             "description": "Assembly's identifier (e.g. GCF_000001405.26) of the assembly. For example, the assembly accession for the GenBank version of the public human reference assembly (GRCh38.p14) is GCA_000001405.29. See further details here: https://www.ncbi.nlm.nih.gov/assembly/model/.",
             "allOf": [
               {
                 "title": "Assembly's CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_ncbi_assembly_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieNcbiAssemblyPattern"
               }
             ],
             "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
           },
-          "assembly_unit_name": {
+          "assemblyUnitName": {
             "type": "string",
             "title": "Assembly unit common name",
-            "meta:property_curie": "OBI:0001948",
+            "meta:propertyCurie": "OBI:0001948",
             "description": "A free-text common name (e.g. 'chr17') that is used to denote the sequence assembly unit.",
             "minLength": 1,
             "examples": [ "Chromosome 2", "MT", "chr17", "chr20", "18" ]
           },
-          "ncbi_assembly_unit_accession": {
+          "ncbiAssemblyUnitAccession": {
             "type": "string",
             "title": "NCBI Assembly unit accession",
             "description": "NCBI's identifier (e.g. ) of the assembly unit. An assembly unit is defined as the collection of sequences used to define discrete parts of an assembly. Commonly assembly units are entire chromosomes (e.g. Chromosome 1 of human genome), scaffolds or different types of sequences (e.g. Mitochondrial DNA). For example, GenBank's accession: (1) for the assembly unit of the human chromosome 1 is [NC_000001.11](https://www.ncbi.nlm.nih.gov/nuccore/NC_000001.11) (for the human reference assembly GRCh38.p14); (2) and for the complete mitochondrion genome of a human it is [NC_012920.1](https://www.ncbi.nlm.nih.gov/nuccore/NC_012920.1). See further details here: https://www.ncbi.nlm.nih.gov/assembly/model/.",
             "allOf": [
               {
                 "title": "RefSeq accession CURIE",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_refseq_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieRefseqPattern"
               }
             ],
             "examples": ["refseq:NC_000001.11", "refseq:NC_012920.1"]
@@ -2711,81 +2711,81 @@
         "anyOf": [
           {
             "title": "Or the Assembly accession is required",
-            "required": ["ncbi_assembly_accession"]
+            "required": ["ncbiAssemblyAccession"]
           },
           {
             "title": "Or the Assembly unit accession is required",
-            "required": ["ncbi_assembly_unit_accession"]
+            "required": ["ncbiAssemblyUnitAccession"]
           }
         ]
         
       },
 
-      "genomic_sequence_descriptor": {
+      "genomicSequenceDescriptor": {
         "type": "object",
         "title": "Genomic sequence descriptor",
-        "meta:property_curie": "GENO:0000960",
+        "meta:propertyCurie": "GENO:0000960",
         "description": "Node used to describe with sufficient detail a genomic sequence (e.g. Human Chromosome X: 71366222-71532374 forward strand), defined as a biological sequence that is of genomic origin (i.e. carries sequence from the genome of a cell or organism).",
         "additionalProperties": false,
         "properties": {
-          "assembly_descriptor": {
+          "assemblyDescriptor": {
             "title": "Assembly descriptor",
-            "meta:property_curie": "topic:0196",
+            "meta:propertyCurie": "topic:0196",
             "description": "Node to identify the assembly of the locus of interest.",
-            "$ref": "./EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
+            "$ref": "./EGA.common-definitions.json#/definitions/ncbiAssemblyDescriptor"
           },
-          "sequence_coordinates": {
+          "sequenceCoordinates": {
             "title": "DNA Sequence coordinates",
             "description": "Node to define que specific sequence coordinates of the genomic feature within the assembly.",
-            "$ref": "./EGA.common-definitions.json#/definitions/sequence_coordinates"
+            "$ref": "./EGA.common-definitions.json#/definitions/sequenceCoordinates"
           },
-          "dna_sequence_strand": {
+          "dnaSequenceStrand": {
             "title": "DNA Sequence strand",
-            "$ref": "./EGA.common-definitions.json#/definitions/dna_sequence_strand"
+            "$ref": "./EGA.common-definitions.json#/definitions/dnaSequenceStrand"
           },
-          "nucleic_acid_sequence": {
+          "nucleicAcidSequence": {
             "title": "Nucleic acid sequence of the locus",
-            "$ref": "./EGA.common-definitions.json#/definitions/nucleic_acid_sequence"
+            "$ref": "./EGA.common-definitions.json#/definitions/nucleicAcidSequence"
           }
         },
         "anyOf": [
           {
             "title": "Either the full position context is given",
-            "required": ["assembly_descriptor", "sequence_coordinates", "dna_sequence_strand"]
+            "required": ["assemblyDescriptor", "sequenceCoordinates", "dnaSequenceStrand"]
           },
           {
             "title": "Or at least the sequence itself is given",
-            "required": ["nucleic_acid_sequence"]
+            "required": ["nucleicAcidSequence"]
           }
         ]
       },
 
-      "sequence_coordinates": {
+      "sequenceCoordinates": {
         "type": "object",
         "title": "Sequence coordinates",
-        "meta:property_curie": "data:2012",
+        "meta:propertyCurie": "data:2012",
         "description": "A position in a map (for example a genetic map), either a single position (e.g. 71366222) or a region interval (e.g. 71366222-71532374). Used to define coordinates within an assembly unit.",
         "additionalProperties": false,
         "properties": {
-          "single_position": {
+          "singlePosition": {
             "title": "Single position",
-            "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
+            "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
           },
-          "sequence_interval": {
+          "sequenceInterval": {
             "type": "object",
             "title": "Sequence interval",
-            "meta:property_curie": "GENO:0000902",
+            "meta:propertyCurie": "GENO:0000902",
             "description": "The location of a sequence feature in a genome, defined by its start (e.g. 71366222) and end (e.g. 71532374) position on some reference genomic coordinate system. Positions are always represented by contiguous spans using interbase coordinates or coordinate ranges. Both coordinates are inclusive: the sequence bounds are included in the described genomic feature. In other words, if the sequence interval is 71366222-71532374, both 71366222 and 71532374 coordinates are included in the feature.",
             "required": ["start", "end"],
             "additionalProperties": false,
             "properties": {
               "start": {
                 "title": "Start position",
-                "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
+                "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
               },
               "end": {
                 "title": "End position",
-                "$ref": "./EGA.common-definitions.json#/definitions/single_sequence_position"
+                "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
               }
             }
           }
@@ -2793,16 +2793,16 @@
         "anyOf": [
           {
             "title": "Either a single position is given",
-            "required": ["single_position"]
+            "required": ["singlePosition"]
           },
           {
             "title": "Or the whole sequence interval",
-            "required": ["sequence_interval"]
+            "required": ["sequenceInterval"]
           }
         ]
       },
 
-      "dna_sequence_strand": {
+      "dnaSequenceStrand": {
         "type": "string",
         "title": "DNA Sequence strand",
         "description": "DNA sequence is double-stranded. By convention, for a reference chromosome, one whole strand is designated the 'forward strand' and the other the 'reverse strand'. This designation is arbitrary and sometimes the terms 'plus strand' and 'minus strand', respectively, are used instead. A genomic feature can live on a DNA strand in one of two orientations. For instance, a gene is said to have a coding strand (also known as its 'sense strand'), and a template strand (also known as its 'antisense strand'), which can be forward or reverse strands depending on which contain the nucleotide sequence the RNA polymerase reads to create its RNA product. Annotations such as Ensembl and UCSC are concerned with the coding sequences of genes, so when they say a gene is on the forward strand, it means the gene's coding sequence is on the forward strand. To follow through again, that means that during transcription of this forward-strand gene, the gene's template sequence is read from the reverse strand, producing an mRNA that matches the sequence on the forward strand. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -2813,16 +2813,16 @@
         }
       },
 
-      "nucleic_acid_sequence": {
+      "nucleicAcidSequence": {
         "type": "string",
         "title": "Nucleic acid sequence",
-        "meta:property_curie": "data:2977",
+        "meta:propertyCurie": "data:2977",
         "description": "Sequence of characters representing a specific nucleic (i.e. molecular species - e.g. Adenine) or groupings of these (through ambiguity codes), using [one-letter IUPAC abbreviations](https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes).",
         "pattern": "^([\\.-]*[ACGTURYKMSWBDHVNX]+[\\.-]*)+$",
         "examples": ["ACTGCCG", "CTGCGCGCGCT", "KM-AGT-X-N"]        
       },
 
-      "single_sequence_position": {
+      "singleSequencePosition": {
         "type": "number",
         "title": "Single sequence position",
         "description": "A single 1-based (first base of the assembly unit is 1, not 0) sequence coordinate, inclusive. It can be used to describe the start or end coordinates of a sequence interval, or directly a single coordinate within a sequence.",
@@ -2830,7 +2830,7 @@
         "examples": [71366222, 36592394, 1]
       },
 
-      "curie_general_pattern": {
+      "curieGeneralPattern": {
         "type": "string",
         "title": "Compact URI (CURIE) pattern",
         "description": "A [W3C Compact URI](https://www.w3.org/TR/curie/) formatted string. A CURIE string has the structure ``prefix``:``reference``, as defined by the W3C syntax. Even though we do not restrict prefixes, we recommend that the term used as ``prefix`` is uniformely resolved. In other words, it is better to use prefixes (e.g. 'ensembl') from identifiers.org.",
@@ -2838,7 +2838,7 @@
         "examples": ["ensembl:ENSG00000139618", "HGNC:11535", "data:1026", "EFO:0003815"]
       },
 
-      "curie_refseq_pattern": {
+      "curieRefseqPattern": {
         "type": "string",
         "title": "RefSeq accessions' [data:1098] CURIE pattern",
         "description": "The Reference Sequence (RefSeq) CURIEs take the structure of ``refseq``:``accession``. [RefSeq accessions](https://registry.identifiers.org/registry/refseq) [data:1098] have special prefixes (e.g. 'NM_' for protein-coding transcripts - mRNA) based on the category of the object. The accession can also have a version attached as a suffix (e.g. '.23'). Their records are integrated into [NCBI's resources](https://www.ncbi.nlm.nih.gov/refseq/) including the Nucleotide, Protein, and BLAST databases and can be easily identified by the keyword 'RefSeq' and by their distinct accession prefixes that define their type (see further details at [doi:10.1093/nar/gkv1189](https://academic.oup.com/nar/article/44/D1/D733/2502674).",
@@ -2846,7 +2846,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],        
         "oneOf": [
@@ -2929,7 +2929,7 @@
         "examples": ["NC_001502.1", "NZ_AP024564.1", "NG_046887.1", "NP_001006685.1", "NZ_AMGO01000001.1"]
       },
 
-      "curie_hgnc_symbol_pattern": {
+      "curieHgncSymbolPattern": {
         "type": "string",
         "title": "HGNC symbol CURIE pattern",
         "description": "The HGNC (HUGO Gene Nomenclature Committee) provides an approved gene name and symbol (short-form abbreviation) for each known human gene. All approved symbols are stored in the HGNC database, and each symbol is unique. This collection refers to records using the HGNC symbol. See further details here: https://registry.identifiers.org/registry/hgnc.symbol",
@@ -2937,13 +2937,13 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],
         "examples": ["hgnc.symbol:DAPK1", "hgnc.symbol:TAF1"]
       },
 
-      "curie_hgnc_identifier_pattern": {
+      "curieHgncIdentifierPattern": {
         "type": "string",
         "title": "HGNC identifier CURIE pattern",
         "description": "The HGNC (HUGO Gene Nomenclature Committee) provides an approved gene name and symbol (short-form abbreviation) for each known human gene. All approved symbols are stored in the HGNC database, and each symbol is unique. HGNC identifiers refer to records in the HGNC symbol database. See further details here: https://registry.identifiers.org/registry/hgnc",
@@ -2951,13 +2951,13 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],
         "examples": ["hgnc:2674", "HGNC:11535"]
       },
 
-      "curie_ncbi_gene_identifier_pattern": {
+      "curieNcbiGeneIdentifierPattern": {
         "type": "string",
         "title": "NCBI Gene identifier CURIE pattern",
         "description": "Entrez Gene is the NCBI's database for gene-specific information, focusing on completely sequenced genomes, those with an active research community to contribute gene-specific information, or those that are scheduled for intense sequence analysis. See further details here: https://registry.identifiers.org/registry/ncbigene",
@@ -2965,13 +2965,13 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],
         "examples": ["ncbigene:100010", "ncbigene:270627"]
       },
 
-      "curie_ncbi_assembly_pattern": {
+      "curieNcbiAssemblyPattern": {
         "type": "string",
         "title": "NCBI Assembly CURIE pattern",
         "description": "The assembly accession starts with a three letter prefix, GCA for GenBank assemblies and GCF for RefSeq assemblies. This is followed by an underscore and 9 digits (e.g. '_000001405'). A version (e.g. '.26') is then added to the accession. See further details here: https://registry.identifiers.org/registry/assembly",
@@ -2979,24 +2979,24 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],
         "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
       },
 
-      "assay_technology_descriptor": {
+      "assayTechnologyDescriptor": {
         "type": "object",
         "title": "Assay technology",
-        "meta:property_curie": "EFO:0000548",
+        "meta:propertyCurie": "EFO:0000548",
         "description": "Metadata of the assay instrument (e.g. sequencer Illumina NextSeq 500) used to obtain the raw data (e.g. sequence files) of an assay.",
-        "required": ["assay_instrument", "assay_instrument_platform"],
+        "required": ["assayInstrument", "assayInstrumentPlatform"],
         "additionalProperties": false,
         "properties": {
-          "assay_instrument": {
+          "assayInstrument": {
             "type": "string",
             "title": "Assay's instrument category",
-            "meta:property_curie": "EFO:0002773",
+            "meta:propertyCurie": "EFO:0002773",
             "description": "The general categories (e.g. sequencers) in which assay instruments are categorized. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
             "enum": [ "array", "sequencer" ],
             "meta:enum": {
@@ -3004,7 +3004,7 @@
               "sequencer": "[EFO:0003739][Sequencer instrument](http://www.ebi.ac.uk/efo/EFO_0003739), an instrument that determines the order of nucleic acids in their sequences." 
             }
           },
-          "assay_instrument_platform": {
+          "assayInstrumentPlatform": {
             "type": "string",
             "title": "Assay instrument label",
             "description": "Label (e.g. 'Illumina HiSeq 2500'), chosen from a list of controlled vocabulary (CV), of the technology used at the experiment. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -3016,10 +3016,10 @@
           {
             "title": "Asserting array technology controlled vocabulary (CV)",
             "properties": {
-              "assay_instrument": {
+              "assayInstrument": {
                 "enum": [ "array" ]
               },
-              "assay_instrument_platform": {
+              "assayInstrumentPlatform": {
                 "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json"
               }
             }              
@@ -3027,10 +3027,10 @@
           {
             "title": "Asserting sequencer technology controlled vocabulary (CV)",
             "properties": {
-              "assay_instrument": {
+              "assayInstrument": {
                 "enum": [ "sequencer" ]
               },
-              "assay_instrument_platform": {
+              "assayInstrumentPlatform": {
                 "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json"
               }
             }              
@@ -3038,7 +3038,7 @@
         ]
       },
 
-      "library_layout": {
+      "libraryLayout": {
         "type": "string",
         "title": "Sequencing library layout",
         "description": "Whether the sequenced reads are paired or single. In other words, if the sequencing assay is paired- (OBI:0001850) or single-end (OBI:0002485). Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -3049,10 +3049,10 @@
         }
       },
 
-      "spot_descriptor": {
+      "spotDescriptor": {
         "type": "array",
         "title": "Spot descriptor",
-        "description": "The 'spot_descriptor' specifies how to decode the individual reads of interest from the monolithic spot sequence. The spot descriptor contains aspects of the experimental design, platform, and processing information. There will be two methods of specification: one will be an index into a table of typical decodings, the other being an exact specification. This construct is needed for loading data and for interpreting the loaded sequencing assays. It can be omitted if the loader can infer read layout (from multiple input files or from one input files).",
+        "description": "The 'spotDescriptor' specifies how to decode the individual reads of interest from the monolithic spot sequence. The spot descriptor contains aspects of the experimental design, platform, and processing information. There will be two methods of specification: one will be an index into a table of typical decodings, the other being an exact specification. This construct is needed for loading data and for interpreting the loaded sequencing assays. It can be omitted if the loader can infer read layout (from multiple input files or from one input files).",
         "minItems": 1,
         "additionalProperties": false,
         "uniqueItems": true,
@@ -3061,15 +3061,15 @@
           "title": "Spot decode spec",
           "description": "",
           "additionalProperties": false,
-          "required": ["read_specs"],
+          "required": ["readSpecs"],
           "properties": {
-            "spot_length": {
+            "spotLength": {
               "type": "integer",
               "title": "Spot length",
               "description": "Number of base/color calls, cycles, or flows per spot (raw sequence length or flow length including all application and technical tags and mate pairs, but not including gap lengths). This value will be platform dependent, library dependent, and possibly run dependent. Variable length platforms will still have a constant flow/cycle length.",
               "minInclusive": 0
             },
-            "read_specs": {
+            "readSpecs": {
               "type": "array",
               "title": "Read specs",
               "description": "",
@@ -3082,19 +3082,19 @@
                 "additionalProperties": false,
                 "required": [""],
                 "properties": {
-                  "read_index": {
+                  "readIndex": {
                     "type": "string",
                     "title": "Read index",
                     "description": "READ_INDEX starts at 0 and is incrementally increased for each sequential READ_SPEC within a SPOT_DECODE_SPEC.",
                     "minLength": 1
                   },
-                "read_label": {
+                "readLabel": {
                   "type": "string",
                   "title": "Read label",
                   "description": "READ_LABEL is a name for this tag, and can be used to on output to determine read name, for example F or R.",
                   "minLength": 1
                 },
-                "read_class": {
+                "readClass": {
                   "type": "string",
                   "title": "Read class",
                   "description": "",
@@ -3104,7 +3104,7 @@
                     "Technical Read": ""
                   }
                 },
-                "read_type": {
+                "readType": {
                   "type": "string",
                   "title": "Read type",
                   "description": "",
@@ -3119,20 +3119,20 @@
                     "Other": "" 
                   }
                 },
-                "relative_order": {
+                "relativeOrder": {
                   "type": "object",
                   "title": "Relative order",
                   "description": "The read is located beginning at the offset or cycle relative to another read. This choice is appropriate for example when specifying a read that follows a variable length expected sequence(s).",
                   "additionalProperties": false,
                   "required": [""],        
                   "properties": {
-                    "follows_read_index": {
+                    "followsReadIndex": {
                       "type": "integer",
                       "title": "Follows read index",
                       "description": "Specify the read index that precedes this read.",
                       "minInclusive": 0      
                     },
-                    "precedes_read_index": {
+                    "precedesReadIndex": {
                       "type": "integer",
                       "title": "",
                       "description": "Specify the read index that follows this read.",
@@ -3140,25 +3140,25 @@
                     }
                   }                    
                 },
-                "base_coord": {
+                "baseCoord": {
                   "type": "integer",
                   "title": "Base coord",
                   "description": "The location of the read start in terms of base count (1 is beginning of spot)"
                 },
-                "expected_basecall_table": {
+                "expectedBasecallTable": {
                   "type": "object",
                   "title": "Expected basecall table",
                   "description": "A set of choices of expected basecalls for a current read. Read will be zero-length if none is found.",    
                   "additionalProperties": false,
                   "required": ["basecalls"],        
                   "properties": {
-                    "default_length": {
+                    "defaultLength": {
                       "type": "integer",
                       "title": "Default length",
                       "description": "Specify whether the spot should have a default length for this tag if the expected base cannot be matched.",
                       "minInclusive": 0
                     },
-                    "base_coord": {
+                    "baseCoord": {
                       "type": "integer",
                       "title": "Base coord",
                       "description": "Specify an optional starting point for tag (base offset from 1).",   
@@ -3177,33 +3177,33 @@
                         "additionalProperties": false,
                         "required": [""],              
                         "properties": {
-                          "read_group_tag": {
+                          "readGroupTag": {
                             "type": "string",
                             "title": "Read group tag",
                             "description": "When match occurs, the read will be tagged with this group membership.",
                             "minLength": 1  
                           },
-                          "min_match": {
+                          "minMatch": {
                             "type": "integer",
                             "title": "Min match",
                             "description": "Minimum number of matches to trigger identification.",   
                             "minInclusive": 0            
                           },
-                          "max_mismatch": {
+                          "maxMismatch": {
                             "type": "integer",
                             "title": "Max mismatch",
                             "description": "Maximum number of mismatches",   
                             "minInclusive": 0         
                           },
-                          "match_edge": {
+                          "matchEdge": {
                             "type": "string",
                             "title": "Match edge",
-                            "description": "Where the match should occur. Changes the rules on how min_match and max_mismatch are counted.",
+                            "description": "Where the match should occur. Changes the rules on how minMatch and maxMismatch are counted.",
                             "enum": ["full", "start", "end"],
                             "meta:enum": {
-                              "full": "Only @max_mismatch influences matching process", 
-                              "start": "Both matches and mismatches are counted. When @max_mismatch is exceeded - it is not a match. When @min_match is reached - match is declared.", 
-                              "end": "Both matches and mismatches are counted. When @max_mismatch is exceeded - it is not a match. When @min_match is reached - match is declared." 
+                              "full": "Only @maxMismatch influences matching process", 
+                              "start": "Both matches and mismatches are counted. When @maxMismatch is exceeded - it is not a match. When @minMatch is reached - match is declared.", 
+                              "end": "Both matches and mismatches are counted. When @maxMismatch is exceeded - it is not a match. When @minMatch is reached - match is declared." 
                             }
                           }
                         }    
@@ -3218,10 +3218,10 @@
         }        
       },
       
-      "type_of_data": {
+      "typeOfData": {
         "type": "string",
         "title": "Type of data",
-        "meta:property_curie": "IAO:0000100",
+        "meta:propertyCurie": "IAO:0000100",
         "description": "Type of data an experiment or analysis can produce (i.e. output), or an analysis can use as input. For example, in a sequencing experiment the output data would be 'genomic data', while that same type of data could be the input type of data for an analysis, which would then output 'processed sequencing data'. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
         "enum": ["gene list", "genomic data", "metagenomic data", "metatranscriptomic data", "synthetic DNA data", "transcriptomic data", "viral RNA data", "processed sequencing data", "processed array data"],
         "meta:enum": {
@@ -3237,28 +3237,28 @@
         }
       },
 
-      "reference_alignment_details": {
+      "referenceAlignmentDetails": {
         "type": "array",
         "title": "Reference assembly and sequence details",
-        "description": "Node containing the information of the reference assembly that was used to obtain the sequence alignment. For example, processing raw sequence FastQ files aligning it to a reference sequence (e.g. human Chromosome X of GRCh38's assembly), obtaining aligned sequences (e.g. BAM format). In this array one can list the used assembly (e.g. GRCh38.p14), the used assembly units (e.g. refseq:NC_000001.11), or a combination of both. In order to ease the interpretation of the data, it is important to notice that the field 'assembly_unit_name' shall correspond to how the Reference Sequence is labelled in submission file(s) (e.g. '1' for chromosome 1). This name is equivalent to the SQ label (the reference sequence dictionary) in BAM (see [documentation for v1](https://samtools.github.io/hts-specs/SAMv1.pdf)) and optional when submitted file uses INSDC accession.version",
+        "description": "Node containing the information of the reference assembly that was used to obtain the sequence alignment. For example, processing raw sequence FastQ files aligning it to a reference sequence (e.g. human Chromosome X of GRCh38's assembly), obtaining aligned sequences (e.g. BAM format). In this array one can list the used assembly (e.g. GRCh38.p14), the used assembly units (e.g. refseq:NC_000001.11), or a combination of both. In order to ease the interpretation of the data, it is important to notice that the field 'assemblyUnitName' shall correspond to how the Reference Sequence is labelled in submission file(s) (e.g. '1' for chromosome 1). This name is equivalent to the SQ label (the reference sequence dictionary) in BAM (see [documentation for v1](https://samtools.github.io/hts-specs/SAMv1.pdf)) and optional when submitted file uses INSDC accession.version",
         "additionalProperties": false,
         "uniqueItems": true,
         "minItems": 1,
         "items": {
           "title": "One item containing metadata of the assembly or assembly unit.",
-          "$ref": "./EGA.common-definitions.json#/definitions/ncbi_assembly_descriptor"
+          "$ref": "./EGA.common-definitions.json#/definitions/ncbiAssemblyDescriptor"
         }
       },
 
-      "organism-part-entity": {
+      "organismPartEntity": {
         "type": "string",
         "title": "Compact URI (CURIE) of the UBERON's organism part",
-        "meta:property_curie": "EFO:0000635",
+        "meta:propertyCurie": "EFO:0000635",
         "description": "The part of organism's anatomy or substance arising from an organism from which the biomaterial was derived, excludes cells. E.g. tissue, organ, system, sperm, blood or body location (arm). Search for yours at: http://www.ebi.ac.uk/efo/EFO_0000635. This property can be used to describe a sampling site or the morphological site of a disease, for example.",
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
           }
         ],
         "graphRestriction":  {
@@ -3271,111 +3271,111 @@
         "examples": [ "UBERON:0000956", "UBERON:0006530" ]
       },
 
-      "r-type-referenced_by": {
+      "rTypeReferencedBy": {
         "type": "object",
-        "title": "Relationship type: referenced_by",
+        "title": "Relationship type: referencedBy",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "referenced_by"
+          "rType": {
+            "const": "referencedBy"
           } 
         }
       },
 
-      "r-type-grouped_with": {
+      "r-type-groupedWith": {
         "type": "object",
-        "title": "Relationship type: grouped_with",
+        "title": "Relationship type: groupedWith",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "grouped_with"
+          "rType": {
+            "const": "groupedWith"
           } 
         }
       },
 
-      "r-type-member_of": {
+      "r-type-memberOf": {
         "type": "object",
-        "title": "Relationship type: member_of",
+        "title": "Relationship type: memberOf",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "member_of"
+          "rType": {
+            "const": "memberOf"
           } 
         }
       },
 
-      "r-type-is_after": {
+      "r-type-isAfter": {
         "type": "object",
-        "title": "Relationship type: is_after",
+        "title": "Relationship type: isAfter",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "is_after"
+          "rType": {
+            "const": "isAfter"
           } 
         }
       },
 
-      "r-type-child_of": {
+      "r-type-childOf": {
         "type": "object",
-        "title": "Relationship type: child_of",
+        "title": "Relationship type: childOf",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "child_of"
+          "rType": {
+            "const": "childOf"
           } 
         }
       },
 
-      "r-type-develops_from": {
+      "r-type-developsFrom": {
         "type": "object",
-        "title": "Relationship type: develops_from",
+        "title": "Relationship type: developsFrom",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "develops_from"
+          "rType": {
+            "const": "developsFrom"
           } 
         }
       },
 
-      "r-type-family_relationship_with": {
+      "r-type-familyRelationshipWith": {
         "type": "object",
-        "title": "Relationship type: family_relationship_with",
+        "title": "Relationship type: familyRelationshipWith",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "family_relationship_with"
+          "rType": {
+            "const": "familyRelationshipWith"
           } 
         }
       },
 
-      "r-type-same_as": {
+      "rTypeSameAs": {
         "type": "object",
-        "title": "Relationship type: same_as",
+        "title": "Relationship type: sameAs",
         "description": "Node to be used as a relationship type for relationship contraints.",
-        "required": [ "r_type" ],
+        "required": [ "rType" ],
         "properties": {
-          "r_type": {
-            "const": "same_as"
+          "rType": {
+            "const": "sameAs"
           } 
         }
       },
 
-      "r-target-policy": {
+      "rTargetPolicy": {
         "type": "object",
         "title": "Relationship target: Policy",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "policy" 
               }
             }
@@ -3383,15 +3383,15 @@
         }
       },
 
-      "r-source-policy": {
+      "rSourcePolicy": {
         "type": "object",
         "title": "Relationship source: Policy",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "policy" 
               }
             }
@@ -3399,15 +3399,15 @@
         }
       },
 
-      "r-target-DAC": {
+      "rTargetDAC": {
         "type": "object",
         "title": "Relationship target: DAC",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "DAC" 
               }
             }
@@ -3415,15 +3415,15 @@
         }
       },
 
-      "r-source-DAC": {
+      "rSourceDAC": {
         "type": "object",
         "title": "Relationship source: DAC",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "DAC" 
               }
             }
@@ -3431,15 +3431,15 @@
         }
       },
 
-      "r-target-dataset": {
+      "rTargetDataset": {
         "type": "object",
         "title": "Relationship target: dataset",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "dataset" 
               }
             }
@@ -3447,15 +3447,15 @@
         }
       },
 
-      "r-source-dataset": {
+      "rSourceDataset": {
         "type": "object",
         "title": "Relationship source: dataset",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "dataset" 
               }
             }
@@ -3463,15 +3463,15 @@
         }
       },
 
-      "r-target-analysis": {
+      "rTargetAnalysis": {
         "type": "object",
         "title": "Relationship target: analysis",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "analysis" 
               }
             }
@@ -3479,15 +3479,15 @@
         }
       },
 
-      "r-source-analysis": {
+      "rSourceAnalysis": {
         "type": "object",
         "title": "Relationship source: analysis",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "analysis" 
               }
             }
@@ -3495,15 +3495,15 @@
         }
       },
 
-      "r-target-sample": {
+      "rTargetSample": {
         "type": "object",
         "title": "Relationship target: sample",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "sample" 
               }
             }
@@ -3511,15 +3511,15 @@
         }
       },
 
-      "r-source-sample": {
+      "rSourceSample": {
         "type": "object",
         "title": "Relationship source: sample",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "sample" 
               }
             }
@@ -3527,15 +3527,15 @@
         }
       },
 
-      "r-target-experiment": {
+      "rTargetExperiment": {
         "type": "object",
         "title": "Relationship target: experiment",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "experiment" 
               }
             }
@@ -3543,15 +3543,15 @@
         }
       },
 
-      "r-source-experiment": {
+      "rSourceExperiment": {
         "type": "object",
         "title": "Relationship source: experiment",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "experiment" 
               }
             }
@@ -3559,15 +3559,15 @@
         }
       },
 
-      "r-source-individual": {
+      "rSourceIndividual": {
         "type": "object",
         "title": "Relationship source: individual",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "individual" 
               }
             }
@@ -3575,15 +3575,15 @@
         }
       },
 
-      "r-target-individual": {
+      "rTargetIndividual": {
         "type": "object",
         "title": "Relationship target: individual",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "individual" 
               }
             }
@@ -3591,15 +3591,15 @@
         }
       },
 
-      "r-source-protocol": {
+      "rSourceProtocol": {
         "type": "object",
         "title": "Relationship source: protocol",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "protocol" 
               }
             }
@@ -3607,15 +3607,15 @@
         }
       },
 
-      "r-target-protocol": {
+      "rTargetProtocol": {
         "type": "object",
         "title": "Relationship target: protocol",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "protocol" 
               }
             }
@@ -3623,15 +3623,15 @@
         }
       },
 
-      "r-source-submission": {
+      "rSourceSubmission": {
         "type": "object",
         "title": "Relationship source: submission",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "submission" 
               }
             }
@@ -3639,15 +3639,15 @@
         }
       },
 
-      "r-target-submission": {
+      "rTargetSubmission": {
         "type": "object",
         "title": "Relationship target: submission",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "submission" 
               }
             }
@@ -3655,79 +3655,79 @@
         }
       },
 
-      "r-source-external_accession": {
+      "r-source-externalAccession": {
         "type": "object",
-        "title": "Relationship source: external_accession",
+        "title": "Relationship source: externalAccession",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
-                "const": "external_accession" 
+              "objectType": {
+                "const": "externalAccession" 
               }
             }
           } 
         }
       },
 
-      "r-target-external_accession": {
+      "r-target-externalAccession": {
         "type": "object",
-        "title": "Relationship target: external_accession",
+        "title": "Relationship target: externalAccession",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
-                "const": "external_accession" 
+              "objectType": {
+                "const": "externalAccession" 
               }
             }
           } 
         }
       },
 
-      "r-source-external_URL": {
+      "r-source-externalURL": {
         "type": "object",
-        "title": "Relationship source: external_URL",
+        "title": "Relationship source: externalURL",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
-                "const": "external_URL" 
+              "objectType": {
+                "const": "externalURL" 
               }
             }
           } 
         }
       },
 
-      "r-target-external_URL": {
+      "r-target-externalURL": {
         "type": "object",
-        "title": "Relationship target: external_URL",
+        "title": "Relationship target: externalURL",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
-                "const": "external_URL" 
+              "objectType": {
+                "const": "externalURL" 
               }
             }
           } 
         }
       },
 
-      "r-source-study": {
+      "rSourceStudy": {
         "type": "object",
         "title": "Relationship source: study",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "study" 
               }
             }
@@ -3735,15 +3735,15 @@
         }
       },
 
-      "r-target-study": {
+      "rTargetStudy": {
         "type": "object",
         "title": "Relationship target: study",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "study" 
               }
             }
@@ -3751,15 +3751,15 @@
         }
       },
 
-      "r-target-assay": {
+      "rTargetAssay": {
         "type": "object",
         "title": "Relationship target: assay",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_target" ],
+        "required": [ "rTarget" ],
         "properties": {
-          "r_target": {
+          "rTarget": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "assay" 
               }
             }
@@ -3767,15 +3767,15 @@
         }
       },
 
-      "r-source-assay": {
+      "rSourceAssay": {
         "type": "object",
         "title": "Relationship source: assay",
         "description": "Node to be used as an object type for relationship contraints.",
-        "required": [ "r_source" ],
+        "required": [ "rSource" ],
         "properties": {
-          "r_source": {
+          "rSource": {
             "properties": {
-              "object_type": {
+              "objectType": {
                 "const": "assay" 
               }
             }
@@ -3783,20 +3783,20 @@
         }
       },
 
-      "r-constraint-one-sourced-submission": {
+      "rConstraintOneSourcedSubmission": {
         "title": "Relationship constraint of 1 submission as source",
-        "description": "This node defines a relationship item containing a 'submission' as a source and of type 'referenced_by'. This node can be used with the keyword 'contains' at each relationship array of all objects (but submission), in order to assert that all objects have a submission object (EGAB...) linked to them.",
+        "description": "This node defines a relationship item containing a 'submission' as a source and of type 'referencedBy'. This node can be used with the keyword 'contains' at each relationship array of all objects (but submission), in order to assert that all objects have a submission object (EGAB...) linked to them.",
         "allOf": [
           {
-            "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+            "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
           },
           {
-            "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+            "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
           }
         ]
       },
 
-      "url-uri-pattern": {
+      "urlUriPattern": {
         "type": "string",
         "title": "URL/URI pattern",
         "description": "This object exists to hold the pattern that a URL or URI should have. For it to be referenced elsewhere within this (or other) JSON schema.",
@@ -3804,29 +3804,29 @@
         "examples": [ "https://phenopacket-schema.readthedocs.io/en/latest/externalreference.html", "https://www.ebi.ac.uk/arrayexpress/experiments/E-MEXP-1712/", "https://www.geeksforgeeks.org/check-if-an-url-is-valid-or-not-using-regular-expression/" ]
       },
 
-      "individual-age": {
+      "individualAge": {
         "type": "string",
         "title": "Individual's age",
-        "meta:property_curie": "EFO:0000246",
+        "meta:propertyCurie": "EFO:0000246",
         "description": "Precise age in ISO8601 format of the individual. For example, 'P3Y6M4D' represents a duration of three years, six months and four days.",
         "allOf": [
           {
             "title": "ISO8601 Date pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO8601-duration-pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DurationPattern"
           }
         ],
         "examples": [ "P3Y6M4D", "P23DT23H", "P4Y" ]
       },
 
-      "cell-type-descriptor": {
+      "cellTypeDescriptor": {
         "type": "object",
         "title": "Cell type",
         "description": "Property to describe a cell type: a distinct morphological or functional form of cell.",
-        "meta:property_curie": "EFO:0000324",
+        "meta:propertyCurie": "EFO:0000324",
         "additionalProperties": false,
-        "required": [ "cell_type_curie" ],
+        "required": [ "cellTypeCurie" ],
         "properties": {          
-          "cell_type_curie": {
+          "cellTypeCurie": {
             "type": "string",
             "title": "Compact URI (CURIE) of the cell type",
             "graphRestriction":  {
@@ -3839,11 +3839,11 @@
             "allOf": [
               {
                 "title": "General CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ]
           },
-          "cell_type_label": {
+          "cellTypeLabel": {
             "type": "string",
             "title": "Label of the cell type",
             "minLength": 1,
@@ -3852,15 +3852,15 @@
         }
       },
 
-      "phenotypic-abnormality-descriptor": {
+      "phenotypicAbnormalityDescriptor": {
         "type": "object",
         "title": "Phenotypic abnormality",
         "description": "Property to describe any abnormal (i.e. deviation from normal or average) phenotype (i.e. detectable outward manifestations of a specific genotype).",
-        "meta:property_curie": "HP:0000118",
+        "meta:propertyCurie": "HP:0000118",
         "additionalProperties": false,
-        "required": [ "phenotypic_abnormality_curie" ],
+        "required": [ "phenotypicAbnormalityCurie" ],
         "properties": {          
-          "phenotypic_abnormality_curie": {
+          "phenotypicAbnormalityCurie": {
             "type": "string",
             "title": "Compact URI (CURIE) of the phenotypic abnormality",
             "anyOf": [
@@ -3882,12 +3882,12 @@
             "allOf": [
               {
                 "title": "General CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "examples": [ "HP:0003003", "HP:0010442", "HP:0002515", "NCIT:C17998", "NCIT:C94232" ]
           },
-          "phenotypic_abnormality_label": {
+          "phenotypicAbnormalityLabel": {
             "type": "string",
             "title": "Label of the phenotypic abnormality",
             "minLength": 1,
@@ -3896,15 +3896,15 @@
         }
       },
 
-      "disease-descriptor": {
+      "diseaseDescriptor": {
         "type": "object",
         "title": "Disease",
         "description": "Property to describe a disease (i.e. a disposition to undergo pathological processes because of one or more disorders).",
-        "meta:property_curie": "EFO:0000408",
+        "meta:propertyCurie": "EFO:0000408",
         "additionalProperties": false,
-        "required": [ "disease_curie" ],
+        "required": [ "diseaseCurie" ],
         "properties": {          
-          "disease_curie": {
+          "diseaseCurie": {
             "type": "string",
             "title": "Compact URI (CURIE) of the disease",
             "oneOf": [
@@ -3926,12 +3926,12 @@
             "allOf": [
               {
                 "title": "General CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               }
             ],
             "examples": [ "MONDO:0100096", "EFO:0003101", "NCIT:C17998", "NCIT:C94232" ]
           },
-          "disease_label": {
+          "diseaseLabel": {
             "type": "string",
             "title": "Label of the disease",
             "minLength": 1,

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -138,10 +138,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -167,13 +167,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -182,13 +182,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -195,16 +195,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -6,50 +6,50 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Dataset metadata object. This object is intended to contain metadata about the collection of file-containing objects (ArrayAssay, runs or analyses) subject to controlled access. In other words, a dataset encompasses a set of objects to which access is granted as a whole, since access given to a data requester is access to a dataset, and fall under the same Policy. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/studies)",
-    "required": ["object_id", "object_title", "dataset_type"],
+    "required": ["objectId", "objectTitle", "datasetType"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: an dataset (by using EGA-dataset-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: an dataset (by using EGADatasetIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that dataset EGA ID (EGAD) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-dataset-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGADatasetIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the dataset",
         "description": "Free-form title of the Dataset. It should be the first picture of the dataset content and not contain more than 30 words. It can be used to call out dataset records in searches or displays.",
         "examples": [ "EBI colon cancer dataset" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the dataset",
         "description": "More extensive free-form description of the Dataset. It should include the content of the dataset (number of samples, file types, technology/protocol used to obtain the data…) and not extend more than 4 sentences.",
         "examples": [ "This dataset is related to Project X by grant Y and encompasses samples from group Z, whose DNA was hybridized against a microarray designed for SNPs." ]
       },
 
-      "dataset_type": {
+      "datasetType": {
         "type": "string",
         "title": "Dataset type",
         "description": "Type of the dataset, expressing the overall purpose of the dataset. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition. The CV was inherited from ENA's dataset types.",
@@ -73,7 +73,7 @@
         "examples": [ "whole genome sequencing" ]
       },
 
-      "approximate_release_date": {
+      "approximateReleaseDate": {
         "type": "string",
         "title": "Approximate release date of the dataset",
         "description": "An approximate date of the desired release of the dataset. Bare in mind that this will NOT automatically release the dataset, but instead may be used to set a reminder to the submitter (and EGA's HelpDesk team) in case the dataset was not released by this time. This would help in cases where this step was forgotten by the submitter or release was stalled for some reason.",
@@ -81,7 +81,7 @@
         "allOf": [
           {
             "title": "The date has to match the common date pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO8601-date-pattern"
+            "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
           },
           {
             "title": "We cap the reminder up to 3 years",
@@ -91,7 +91,7 @@
         ]
       },
 
-      "dataset_relationships": {
+      "datasetRelationships": {
         "type": "array",
         "title": "Dataset relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. a policy being linked to a dataset) the EGA.",
@@ -102,59 +102,59 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a dataset",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a dataset.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourcePolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
                         }
                       ]
                     }
@@ -167,44 +167,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -216,11 +216,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "dataset_attributes": {
+      "datasetAttributes": {
         "type": "array",
         "title": "Dataset custom attributes",
         "description": "Custom attributes of a dataset: reusable attributes to encode tag-value pairs (e.g. Tag being 'Targeted loci' and its Value '5:63256183-63258334') with optional units (e.g. 'base pairs'). Its properties are inherited from the common-definitions.json schema.",
@@ -228,7 +228,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
       

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -6,50 +6,50 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its experiment metadata object. An experiment is considered a planned and intentionally designed process performed as part of a study. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_id", "assay_technology", "assay_type_descriptor", "assayed_molecule_type", "experiment_type_specifications"],
+    "required": ["objectId", "assayTechnology", "assayTypeDescriptor", "assayedMoleculeType", "experimentTypeSpecifications"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions.", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions.", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that experiment EGA ID (EGAX) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-experiment-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAExperimentIdPattern"
               }
             }
           }
         ]
       },  
       
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the experiment",
         "description": "An informative experiment title that should serve as an overview of the experiment, including: used technology, samples, purpose... (e.g. 'Affymetrix-X microarray of human breast cancer cell line MCF-7 treated with tamoxifen compared with untreated controls'). This short text can be used to call out experiment records in searches or in displays.",
         "examples": [ "Affymetrix-X microarray of human breast cancer cell line MCF-7 treated with tamoxifen compared with untreated controls" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the experiment",
         "description": "An in-depth description of the biological relevance and intent of the experiment, including the experimental workflow.",
         "examples": [ "The experiment was conducted with the objective of... ...and for that purpose we compared untreated controls against..." ]
       },
 
-      "targeted_loci": {
+      "targetedLoci": {
         "type": "array",
         "title": "Loci of the targeted genomic feature",
         "description": "Array of items that unambiguously define the loci of targeted genomic features in the experiment. For example, if the experiment aim was to detect variants in the human gene TAF1 and TP53, their identifiers will be expected in two items of this array.",
@@ -57,44 +57,44 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/locus_identifier" 
+          "$ref": "./EGA.common-definitions.json#/definitions/locusIdentifier" 
         }
       },
 
-      "assay_technology": {
+      "assayTechnology": {
         "title": "Technology used in the assay",
         "description": "Technology used in the assay. This node allows for an easy filtering of the technology (e.g. a sequencer Illumina NextSeq 500) used to obtain the raw data (e.g. sequence files) in an assay.",
-        "$ref": "./EGA.common-definitions.json#/definitions/assay_technology_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/assayTechnologyDescriptor"
       },
 
-      "assay_type_descriptor": {
+      "assayTypeDescriptor": {
         "type": "object",
         "title": "Type of assay",
-        "meta:property_curie": "OBI:0000070",
+        "meta:propertyCurie": "OBI:0000070",
         "description": "Node defining the type of assay applicable to the experiment. Consists in an overall category (based on the purpose and technology of the instrument [EFO:0002773]) and its possible subtype. Both types and subtypes are taken from controlled vocabulary (CV) lists, stored in the controlled_vocabulary_schemas folder. For example, in a single cell RNA-seq assay the assay type would be 'assay by high throughput sequencer' [EFO:0002697] and its subtype 'RNA-seq of coding RNA from single cells' [EFO:0005684].",
         "additionalProperties": false,
-        "required": ["assay_type"],
+        "required": ["assayType"],
         "properties": {
-          "assay_type": {
+          "assayType": {
             "type": "string",
             "title": "Type of the assay",
-            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
+            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
             "anyOf": [
               {
                 "title": "Array-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json"
               },
               {
                 "title": "Sequencer-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json"
               }
             ],
             "examples": [ "Hi-C", "amplicon sequencing", "assay by high throughput sequencer", "immune sequencing", "ChIP-chip by array", "transcription profiling by array", "microRNA profiling by array", "genotyping by array", "comparative genomic hybridization by array" ]
           },
-          "assay_subtype": {
+          "assaySubtype": {
             "type": "string",
             "title": "Subtype of the assay",
-            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json))",
+            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_dna.json))",
             "examples": [ "MC-4C", "UMI-4C", "single nucleus RNA sequencing", "RNA-seq of coding RNA from single cells", "Quant-seq", "DNA-seq", "ATAC-seq", "DNase Hi-C", "scDNase-seq", "in situ HiC", "exome sequencing" ]
           }
         },
@@ -102,15 +102,15 @@
           {
             "title": "Assay subtypes match DNA/RNA assays",
             "properties": {
-              "assay_subtype": {
+              "assaySubtype": {
                 "anyOf": [
                   {
                     "title": "DNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_dna.json"
                   },
                   {
                     "title": "RNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_rna.json"
                   }
                 ]                 
               }
@@ -122,22 +122,22 @@
               {
                 "title": "Assay type and subtype terms are from the array CV list",
                 "properties": {
-                  "assay_type": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json" 
+                  "assayType": {
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json" 
                   },
-                  "assay_subtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json" 
+                  "assaySubtype": {
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_array.json" 
                   }
                 }
               },
               {
                 "title": "Assay type and subtype terms are from the sequencer CV list",
                 "properties": {
-                  "assay_type": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json" 
+                  "assayType": {
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json" 
                   },
-                  "assay_subtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json" 
+                  "assaySubtype": {
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_sequencer.json" 
                   }
                 }
               }
@@ -146,7 +146,7 @@
         ]
       },
 
-      "assayed_molecule_type": {
+      "assayedMoleculeType": {
         "type": "string",
         "title": "Type of the assayed molecule of the experiment",
         "description": "Node containing information about the assayed molecule: the material entity (e.g. DNA) that was used to generate the data. Choose the specific terms if possible (e.g. if the assayed molecule is cDNA, pick 'cDNA' instead of just 'DNA'). Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -170,44 +170,44 @@
           "total RNA": "[EFO:0004964]" }
       },
 
-      "types_of_output_data": {
+      "typesOfOutputData": {
         "type": "array",
         "title": "Types of output data",
-        "meta:property_curie": "IAO:0000100",
+        "meta:propertyCurie": "IAO:0000100",
         "description": "Types of data the experiment produces.",
         "uniqueItems": true,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/type_of_data"
+          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
         }
       },
 
-      "experiment_type_specifications": {
+      "experimentTypeSpecifications": {
         "type": "object",
         "title": "Experiment type specifications",
         "description": "Node containing additional attributes to describe the experiment, either array experiments (those in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used) or sequencing experiments (those in which a [sequencing instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used). For example, if an array was used, its Array Design Format (ADF) will be expected.",
         "additionalProperties": false,
         "properties": {
-          "array_experiment": {
+          "arrayExperiment": {
             "type": "object",
             "title": "Specifications of an array experiment",
             "description": "Node containing the set of fields specific to an experiment of array-type (i.e. an array was used to obtain the raw data).",
             "additionalProperties": false,
-            "required": ["array_labels", "adf_files"],
+            "required": ["arrayLabels", "adfFiles"],
             "properties": {
-              "array_labels": {
+              "arrayLabels": {
                 "type": "array",
                 "title": "Array label of the experiment",
-                "meta:property_curie": "EFO:0000562",
+                "meta:propertyCurie": "EFO:0000562",
                 "description": "Chemicals conjugated to nucleic acid/proteins to label them before microarray hybridisation. Can be repeated so that dual labelled arrays can be taken into account.",
                 "additionalProperties": false,
                 "uniqueItems": true,
                 "minItems": 1,
                 "items": {
-                  "$ref": "./EGA.common-definitions.json#/definitions/array_label" 
+                  "$ref": "./EGA.common-definitions.json#/definitions/arrayLabel" 
                 }
               },
               
-              "adf_files": {
+              "adfFiles": {
                 "type": "array",
                 "title": "Array Design Format (ADF) [NCIT:C172213] file block",
                 "description": "The array design format (ADF) [NCIT:C172213] is the unique set of probes (with their coordinates) found on the microarray chip. They can be standard (sold by a company) or custom. Its format is of a spreadsheet-like tab-delimited text file with metadata header rows, followed by a multi-column table of probe information. For example, see ADF for [arrayexpress:E-MTAB-3050](https://www.ebi.ac.uk/arrayexpress/files/A-GEOD-28079/A-GEOD-28079.adf.txt) or [arrayexpress:E-MEXP-1712](https://www.ebi.ac.uk/arrayexpress/files/A-AFFY-125/A-AFFY-125.adf.txt). This node is an array of file nodes in case the ADF is given in several formats (e.g. tsv, xlsx, csv...).",
@@ -216,26 +216,26 @@
                 "uniqueItems": true,
                 "items": {
                   "title": "ADF File object",
-                  "$ref": "./EGA.common-definitions.json#/definitions/file_object" 
+                  "$ref": "./EGA.common-definitions.json#/definitions/fileObject" 
                 }
               }
             }
           },
-          "sequencing_experiment": {
+          "sequencingExperiment": {
             "type": "object",
             "title": "Specifications of a sequencing experiment",
             "description": "Node containing the set of fields specific to an experiment of sequencing-type (i.e. a sequencer was used to obtain the raw data).",
             "additionalProperties": false,
-            "required": ["library_layout"],
+            "required": ["libraryLayout"],
             "properties": {
-              "library_layout": {
+              "libraryLayout": {
                 "title": "Library layout of the sequencing experiment",
-                "$ref": "./EGA.common-definitions.json#/definitions/library_layout"
+                "$ref": "./EGA.common-definitions.json#/definitions/libraryLayout"
               },
-              "spot_descriptor": {
+              "spotDescriptor": {
                 "title": "Spot descriptor of the sequencing experiment",
                 "description": "Adapted from current ENA's XSDs without improvements. #! Expected to be investigated.",
-                "$ref": "./EGA.common-definitions.json#/definitions/spot_descriptor"
+                "$ref": "./EGA.common-definitions.json#/definitions/spotDescriptor"
               }
             }
           }
@@ -243,16 +243,16 @@
         "oneOf": [
           {
             "title": "The sequencing experiment descriptors are required",
-            "required": ["sequencing_experiment"]
+            "required": ["sequencingExperiment"]
           },
           {
             "title": "The array experiment descriptors are required",
-            "required": ["array_experiment"]
+            "required": ["arrayExperiment"]
           }
         ]
       },
 
-      "experiment_relationships": {
+      "experimentRelationships": {
         "type": "array",
         "title": "Experiment relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. an experiment being linked to a Sample) the EGA.",
@@ -263,74 +263,74 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for an experiment",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for an experiment.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
-                        },
-                        {
-                          "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
+                        },
+                        {
+                          "title": "Optional one, added here to simplify",
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
                         }
                       ]
                     }
@@ -343,44 +343,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -392,11 +392,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "experiment_attributes": {
+      "experimentAttributes": {
         "type": "array",
         "title": "Experiment custom attributes",
         "description": "Custom attributes of an experiment: reusable attributes to encode tag-value pairs (e.g. Tag being 'additional description' and its Value 'this experiment is a re-do of another 3 experiments due to...') with optional units. Its properties are inherited from the common-definitions.json schema.",
@@ -404,7 +404,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     },
@@ -413,30 +413,30 @@
       {
         "title": "If the assay technology is a sequencer, the experiment type has to match",
         "properties": {
-          "assay_technology": {
+          "assayTechnology": {
             "properties": {
-              "assay_instrument": {
+              "assayInstrument": {
                 "enum": ["sequencer"]
               }
             }
           },
-          "experiment_type_specifications": {
-            "required": ["sequencing_experiment"]
+          "experimentTypeSpecifications": {
+            "required": ["sequencingExperiment"]
           }
         }
       },
       {
         "title": "If the assay technology is an array, the experiment type has to match",
         "properties": {
-          "assay_technology": {
+          "assayTechnology": {
             "properties": {
-              "assay_instrument": {
+              "assayInstrument": {
                 "enum": ["array"]
               }
             }
           },
-          "experiment_type_specifications": {
-            "required": ["array_experiment"]
+          "experimentTypeSpecifications": {
+            "required": ["arrayExperiment"]
           }
         }
       }

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -314,10 +314,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -343,13 +343,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -358,13 +358,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -371,16 +371,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -130,13 +130,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -162,13 +162,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -177,13 +177,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -190,16 +190,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -6,51 +6,51 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its individual metadata object. This object is intended to contain metadata about the individual, also known as the sample donor or subject of study. An individual is defined as a person that participates in an experiment or from which a material sample was derived. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_id", "organism_descriptor", "minimal_public_attributes"],
+    "required": ["objectId", "organismDescriptor", "minimalPublicAttributes"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: a individual (by using EGA-individual-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: a individual (by using EGAIndividualIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that individual EGA ID (EGAI) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-individual-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAIndividualIdPattern"
               }
             }
           }
         ]
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "organism_descriptor": {
-        "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
+      "organismDescriptor": {
+        "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
       },
      
-      "minimal_public_attributes":{
+      "minimalPublicAttributes":{
         "type": "object",
         "title": "Minimal public attributes describing an individual",
         "description": "Among all attributes describing an individual, some may contain identifiable metadata and thus must be private. Nevertheless, there are three/four required attributes (even if they are unknown): subject id, biological sex and phenotype. These shall be displayed and queryable. In the case of a healthy individual (with no phenotypic abnormalities nor diseases), the 'phenotypes' and 'diseases' arrays will contain a reference to 'Unaffected' [NCIT:C94232].",
         "additionalProperties": false,
-        "required": ["subject_id", "biological_sex"],
+        "required": ["subjectId", "biologicalSex"],
         "properties": {
-          "subject_id": {
-            "$ref": "./EGA.common-definitions.json#/definitions/subject_id"
+          "subjectId": {
+            "$ref": "./EGA.common-definitions.json#/definitions/subjectId"
           },
-          "biological_sex": {
-            "$ref": "./EGA.common-definitions.json#/definitions/biological_sex"
+          "biologicalSex": {
+            "$ref": "./EGA.common-definitions.json#/definitions/biologicalSex"
           },
           "phenotypes": {
             "type": "array",
@@ -59,7 +59,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/phenotypic-abnormality-descriptor"
+              "$ref": "./EGA.common-definitions.json#/definitions/phenotypicAbnormalityDescriptor"
             }
           },
           "diseases": {
@@ -69,7 +69,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/disease-descriptor"
+              "$ref": "./EGA.common-definitions.json#/definitions/diseaseDescriptor"
             }
           }
         },
@@ -85,7 +85,7 @@
         ]
       },
 
-      "individual_relationships": {
+      "individualRelationships": {
         "type": "array",
         "title": "Individual relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. a viral sample from BioSamples being linked to a blood sample within the EGA) and within (e.g. a sample being linked to an individual) the EGA.",
@@ -96,60 +96,60 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for an individual",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a individual.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type child_of, family_relationship_with, grouped_with, same_as (optional ones)",
+                  "title": "Allowed relationships of type childOf, familyRelationshipWith, groupedWith, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceIndividual"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetIndividual"
                         }
                       ]
                     }
@@ -162,44 +162,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -211,11 +211,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "individual_attributes": {
+      "individualAttributes": {
         "type": "array",
         "title": "Individual custom attributes",
         "description": "Custom attributes of an individual: reusable attributes to encode tag-value pairs (e.g. Tag being 'age' and its Value '30') with optional units (e.g. 'years'). Its properties are inherited from the common-definitions.json schema.",
@@ -223,7 +223,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }

--- a/schemas/EGA.object-set.json
+++ b/schemas/EGA.object-set.json
@@ -5,34 +5,34 @@
     "title": "EGA object-set metadata schema",
     "meta:version": "0.0.0",
     "$async": true,
-    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate an object set. A set or group of objects is defined as an array of individual objects (e.g. 'sample' or 'experiment'). The minimum length of the array is 1 (i.e. it has to contain at least one object). These objects can be of different nature, and are validated against their corresponding schemas based on the 'schema_descriptor' node within each individual object, which specifies the schema against the individual object needs to be validated. To put it simply, this object-set schema exists to avoid the need of 1 single file per each object: for a submission of 1000 samples we would require 1000 JSON files, each of them corresponding to one of the objects; whereas using an object-set allows us to fit all those objects together in a single file. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_array"],
+    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate an object set. A set or group of objects is defined as an array of individual objects (e.g. 'sample' or 'experiment'). The minimum length of the array is 1 (i.e. it has to contain at least one object). These objects can be of different nature, and are validated against their corresponding schemas based on the 'schemaDescriptor' node within each individual object, which specifies the schema against the individual object needs to be validated. To put it simply, this object-set schema exists to avoid the need of 1 single file per each object: for a submission of 1000 samples we would require 1000 JSON files, each of them corresponding to one of the objects; whereas using an object-set allows us to fit all those objects together in a single file. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
+    "required": ["objectArray"],
     "additionalProperties": false,
     "properties": {
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_array": {
+      "objectArray": {
         "type": "array",
         "title": "Array containing metadata objects",
-        "description": "The array per se containing the list of metadata objects to be validated. For each type of metadata object (e.g. 'sample') its corresponding schema (e.g. 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json#') is applied conditionally based on the value of schema_descriptor[object_type] within each object. This way this array can contain any combination of metadata objects and each will be validated individually against the correct schemas. Notice how the 'schema_descriptor' is a required node for the object-set to be used.",
+        "description": "The array per se containing the list of metadata objects to be validated. For each type of metadata object (e.g. 'sample') its corresponding schema (e.g. 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json#') is applied conditionally based on the value of schemaDescriptor[objectType] within each object. This way this array can contain any combination of metadata objects and each will be validated individually against the correct schemas. Notice how the 'schemaDescriptor' is a required node for the object-set to be used.",
         "minItems": 1,
         "additionalitems": false,
         "uniqueItems": true,
         "items": {
-          "title": "Schemas being conditionally applied based on value of 'object_type' from 'schema_descriptor' in each object.",
-          "description": "Based on the value found within 'object_type' (i.e. if it matches the 'enum' of each type), the corresponding schema (defined within '$ref') is evaluated.",
+          "title": "Schemas being conditionally applied based on value of 'objectType' from 'schemaDescriptor' in each object.",
+          "description": "Based on the value found within 'objectType' (i.e. if it matches the 'enum' of each type), the corresponding schema (defined within '$ref') is evaluated.",
           "anyOf": [
             {
-              "title": "The object's 'schema_descriptor' defines it as an experiment",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an experiment",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["experiment"]
                   }
                 }
@@ -40,11 +40,11 @@
               "$ref": "./EGA.experiment.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an study",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an study",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["study"]
                   }
                 }
@@ -52,11 +52,11 @@
               "$ref": "./EGA.study.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an sample",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an sample",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["sample"]
                   }
                 }
@@ -64,11 +64,11 @@
               "$ref": "./EGA.sample.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an individual",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an individual",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["individual"]
                   }
                 }
@@ -76,11 +76,11 @@
               "$ref": "./EGA.individual.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an submission",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an submission",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["submission"]
                   }
                 }
@@ -88,11 +88,11 @@
               "$ref": "./EGA.submission.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an dataset",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an dataset",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["dataset"]
                   }
                 }
@@ -100,11 +100,11 @@
               "$ref": "./EGA.dataset.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an analysis",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an analysis",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["analysis"]
                   }
                 }
@@ -112,11 +112,11 @@
               "$ref": "./EGA.analysis.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an policy",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an policy",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["policy"]
                   }
                 }
@@ -124,11 +124,11 @@
               "$ref": "./EGA.policy.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an DAC",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an DAC",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["DAC"]
                   }
                 }
@@ -136,11 +136,11 @@
               "$ref": "./EGA.DAC.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as an assay",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as an assay",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["assay"]
                   }
                 }
@@ -148,11 +148,11 @@
               "$ref": "./EGA.assay.json#"
             },
             {
-              "title": "The object's 'schema_descriptor' defines it as a protocol",
-              "required": ["schema_descriptor"],
+              "title": "The object's 'schemaDescriptor' defines it as a protocol",
+              "required": ["schemaDescriptor"],
               "properties": {
-                "schema_descriptor": { 
-                  "object_type": {
+                "schemaDescriptor": { 
+                  "objectType": {
                     "enum": ["protocol"]
                   }
                 }

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -145,7 +145,7 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -171,13 +171,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -186,13 +186,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -6,49 +6,49 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "A policy, also known as Data Access Agreement (DAA), is a contract made between Data User and Data Access Committee. The policy object is expected to contain metadata about such agreement, which should be drafted by the DAC and includes, but is not limited to, details of data use, publication embargoes and storage. Completion of a DAA by the applicant/s should form part of the application process to the DAC. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/dac/documentation)",
-    "required": ["object_id", "object_title", "policy_descriptor"],
+    "required": ["objectId", "objectTitle", "policyDescriptor"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: an policy (by using EGA-policy-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: an policy (by using EGAPolicyIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that policy EGA ID (EGAP) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-policy-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAPolicyIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the policy",
         "description": "Free-form title of the policy. Can be used to call out policy records in searches or displays.",
         "examples": [ "EBI colon cancer policy" ]
       },
     
-      "policy_descriptor":{
+      "policyDescriptor":{
         "type": "object",
         "title": "Policy descriptor",
         "description": "Node containing the full description of the policy, whether it is hosted at some public resourced and referenced here; or directly written here.",
         "additionalProperties": false,
         "properties": {
-          "policy_reference": {
+          "policyReference": {
             "type": "string",
             "title": "Reference to the policy",
             "description": "A publicly accessible reference to the policy, where the updated text of the policy is hosted.",
@@ -58,7 +58,7 @@
               "https://ega-archive.org/submission/dac/documentation" 
             ]
           },
-          "policy_text": {
+          "policyText": {
             "type": "string",
             "title": "Policy text",
             "description": "Text describing in detail the Data Access Agreement (DAA) of the policy.",
@@ -71,16 +71,16 @@
         "anyOf": [
           {
             "title": "Either the policy reference is given",
-            "required": ["policy_reference"]
+            "required": ["policyReference"]
           },
           {
             "title": "Or the policy text is given",
-            "required": ["policy_text"]
+            "required": ["policyText"]
           }
         ]
       },
 
-      "duo_codes_curies": {
+      "duoCodesCuries": {
         "type": "array",
         "title": "Data Use Ontology (DUO) codes' curies",
         "description": "Collection of Data Use Ontology (DUO) codes in Shorter Compact URI (CURIE) format. These allow to semantically tag datasets (bound by policies) with restriction about their usage, making them discoverable automatically based on the authorization level of users, or intended usage. See more info at https://obofoundry.org/ontology/duo.html and search for DUO codes at https://www.ebi.ac.uk/ols/ontologies/duo",
@@ -95,13 +95,13 @@
           "allOf": [
             {
               "title": "General pattern of a CURIE",
-              "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+              "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
             }
           ]
         }
       },
 
-      "policy_relationships": {
+      "policyRelationships": {
         "type": "array",
         "title": "Policy relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. a policy being linked to a policy) the EGA.",
@@ -112,53 +112,53 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a policy",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a policy.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-dataset"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-DAC"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDAC"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourcePolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-policy"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetPolicy"
                         }
                       ]
                     }
@@ -171,44 +171,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -220,11 +220,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "policy_attributes": {
+      "policyAttributes": {
         "type": "array",
         "title": "Policy custom attributes",
         "description": "Custom attributes of a policy: reusable attributes to encode tag-value pairs (e.g. Tag being 'Targeted loci' and its Value '5:63256183-63258334') with optional units (e.g. 'base pairs'). Its properties are inherited from the common-definitions.json schema.",
@@ -232,7 +232,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -199,16 +199,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.protocol.json
+++ b/schemas/EGA.protocol.json
@@ -252,16 +252,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         }
                       ]
                     },
@@ -284,7 +284,7 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -293,13 +293,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.protocol.json
+++ b/schemas/EGA.protocol.json
@@ -306,16 +306,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.protocol.json
+++ b/schemas/EGA.protocol.json
@@ -6,55 +6,55 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its protocol metadata object. A protocol is an information entity of a set of instructions that describe an how a procedure, analysis or experiment is done. Comprises metadata (e.g. Type of protocol) of a plan specification, with sufficient level of detail and quantitative information to communicate it (and thus reproduce it) between investigation agents (i.e. researchers). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": [ "object_id", "protocol_type_descriptor", "protocol_description", "protocol_relationships" ],
+    "required": [ "objectId", "protocolTypeDescriptor", "protocolDescription", "protocolRelationships" ],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions.", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions.", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that protocol EGA ID (EGAO) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-protocol-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAProtocolIdPattern"
               }
             }
           }
         ]
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Name of the protocol",
-        "meta:property_curie": "NCIT:C42614",
+        "meta:propertyCurie": "NCIT:C42614",
         "description": "Name of the protocol (e.g. 'myProtocol-13'). To be defined by the user.",
         "minLength": 1,
         "examples": [ "myProtocol-13", "Treatment for leukemia patients C30", "Sample collection from infected patients" ]
       },
 
-      "protocol_type_descriptor": {
+      "protocolTypeDescriptor": {
         "type": "object",
         "title": "Protocol type descriptor",
         "description": "Node to contain the information about the type and subtype of the protocol. References to ontologies allow for a clear provenance and documentation of the protocol type.",
-        "required": ["protocol_type", "protocol_subtype_curie"],
+        "required": ["protocolType", "protocolSubtypeCurie"],
         "additionalProperties": false,
         "properties": {
-          "protocol_type": {
+          "protocolType": {
             "type": "string",
             "title": "Type of protocol",
-            "meta:property_curie": "OBI:0000272",
+            "meta:propertyCurie": "OBI:0000272",
             "description": "Classification by type of the protocol (e.g. 'Sample collection'), to be chosen from a controlled vocabulary (CV) list. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
             "enum": ["high Content Screen (HCS)", "conversion", "delivery method", "dissection", "dissociation", "enrichment", "extraction", "gene expression", "growth", "hybridization", "hydrolysis collection", "labelling", "nucleic acid library construction", "nucleic acid sequencing", "sample collection", "single cell isolation", "treatment", "data transformation"],
             "meta:enum": {
@@ -79,7 +79,7 @@
             }
           },
 
-          "protocol_subtype": {
+          "protocolSubtype": {
             "type": "string",
             "title": "Subtype of the protocol",
             "description": "Name of the protocol's subtype. We highly recommend the usage of names given to ontologized protocols, specially those at the [Experimental Factor Ontology (EFO)](https://www.ebi.ac.uk/ols/ontologies/efo). For example, if the protocol corresponds to a data transformation of a genome, you may find your subtype at [genome analysis](http://edamontology.org/operation_3918); while treating a patient with a drug would correspond to a [clinical treatment](http://www.ebi.ac.uk/efo/EFO_0007056).",
@@ -87,14 +87,14 @@
             "examples": [ "clinical treatment", "array scanning and feature extraction", "Genome alignment", "Genome annotation", "Genome assembly", "Genome comparison", "Genome feature comparison", "Genome indexing", "Genome visualisation", "Whole genome methylation analysis" ]    
           },
 
-          "protocol_subtype_curie": {
+          "protocolSubtypeCurie": {
             "type": "string",
             "title": "Compact URI (CURIE) of the protocol subtype",
-            "description": "Ontology term in CURIE format (e.g. 'EFO:0005518') of the protocol subtype. Search for the ontologized term at the [Ontology Lookup Service (OLS)](https://www.ebi.ac.uk/ols/index). This allows for a specific designation of the protocol within the overall general of the 'protocol_type' field. For instance, the CURIE for Treatment's subtype 'clinical treatment' would be 'EFO:0003814'. If the protocol does not require a subtype, use the CURIE for the protocol type per se (e.g. 'EFO:0005518' for 'Sample collection').",
+            "description": "Ontology term in CURIE format (e.g. 'EFO:0005518') of the protocol subtype. Search for the ontologized term at the [Ontology Lookup Service (OLS)](https://www.ebi.ac.uk/ols/index). This allows for a specific designation of the protocol within the overall general of the 'protocolType' field. For instance, the CURIE for Treatment's subtype 'clinical treatment' would be 'EFO:0003814'. If the protocol does not require a subtype, use the CURIE for the protocol type per se (e.g. 'EFO:0005518' for 'Sample collection').",
             "allOf": [
               {
                 "title": "General CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curie_general_pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
               },
               {
                 "title": "Ontology validation of it being part of EFO's protocol [OBI:0000272] or planned process [EFO:0004542], or EDAM's Analysis [operation:2945]",
@@ -134,15 +134,15 @@
         }
       },
 
-      "protocol_description": {
+      "protocolDescription": {
         "type": "string",
         "title": "Description of the protocol",
-        "meta:property_curie": "NCIT:C25365",
+        "meta:propertyCurie": "NCIT:C25365",
         "description": "Description of the protocol (e.g. 'First tilt the cell culture flask... ...and finally let it still for 2 hours.'), being descriptive enough to be replicated between institutions or performers.",
         "examples": [ "First tilt the cell culture flask... ...and finally let it still for 2 hours.", "Patients were given a ketogenic diet for 3 weeks at intervals consisting in..." ]
       },
 
-      "protocol_performers": {
+      "protocolPerformers": {
         "type": "array",
         "title": "Protocol performers array",
         "description": "Array of performers' descriptions of those individuals, groups, or institutions that executed the protocol.",
@@ -158,10 +158,10 @@
         }
       },
 
-      "protocol_instruments": {
+      "protocolInstruments": {
         "type": "array",
         "title": "Protocol instrument array",
-        "meta:property_curie": "EFO:0000548",
+        "meta:propertyCurie": "EFO:0000548",
         "description": "Array of instruments used in the protocol. It is not indispensable to provide each and every piece of instruments used, but a set of the ones you would highlight in your protocol for other researchers to know, since it will help them discover your data.",
         "additionalProperties": false,
         "uniqueItems": true,
@@ -169,17 +169,17 @@
         "items": {
           "type": "string",
           "title": "Instrument used in the protocol",
-          "meta:property_curie": "EFO:0000548",
+          "meta:propertyCurie": "EFO:0000548",
           "description": "Free form text to specify the device, which provides a mechanical or electronic function, and was used by the performer of the protocol. We highly recommend the usage of ontologized terms (e.g. 'Oligonucleotide synthesizer') from the [Experimental Factor Ontology (EFO)](http://www.ebi.ac.uk/efo/EFO_0000548) along their CURIEs between square brackets (e.g. '[OBI:0400113]').",
           "minLength": 1,
           "examples": ["Computer [OBI:0400107]", "Oligonucleotide synthesizer [OBI:0400113]", "Sonicator [OBI:0400114]"]
         }
       },
 
-      "protocol_software": {
+      "protocolSoftware": {
         "type": "array",
         "title": "Protocol software array",
-        "meta:property_curie": "IAO:0000010",
+        "meta:propertyCurie": "IAO:0000010",
         "description": "Array of software descriptions used in the protocol. It is not indispensable to provide each and every piece of software used, but a set of the ones you would highlight in your protocol for other researchers to know, since it will help them discover your data.",
         "additionalProperties": false,
         "uniqueItems": true,
@@ -187,14 +187,14 @@
         "items": {
           "type": "string",
           "title": "Software descriptions used in the protocol",
-          "meta:property_curie": "IAO:0000010",
+          "meta:propertyCurie": "IAO:0000010",
           "description": "Free form text to specify the programs and other operating information (including bespoken scripts) used by a computer that were used by the performer of the protocol. We highly recommend the usage of ontologized terms (e.g. 'SAMtools') from the [Software Ontology (SWO)](https://www.ebi.ac.uk/ols/ontologies/swo) along their versions (e.g. 'v3.0.1'), if applicable, and CURIEs between square brackets (e.g. '[SWO:1100143]').",
           "minLength": 1,
           "examples": ["SAMtools v3.0.1 [SWO:1100143]", "MATLAB [SWO:0000005]"]         
         }
       },
 
-      "protocol_relationships": {
+      "protocolRelationships": {
         "type": "array",
         "title": "Protocol relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. a protocol being linked to an experiment) the EGA.",
@@ -205,73 +205,73 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a protocol",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a protocol.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
-                        },
-                        {
-                          "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetStudy"
+                        },
+                        {
+                          "title": "Optional one, added here to simplify",
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetIndividual"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as, member_of (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs, memberOf (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetProtocol"
                         }
                       ]
                     }
@@ -284,38 +284,38 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -327,11 +327,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "protocol_attributes": {
+      "protocolAttributes": {
         "type": "array",
         "title": "Protocol custom attributes",
         "description": "Custom attributes of a protocol: reusable attributes to encode tag-value pairs (e.g. Tag being 'step index' and its Value '2') with optional units. Its properties are inherited from the common-definitions.json schema.",
@@ -339,7 +339,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -393,16 +393,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         }
                       ]
                     },
@@ -425,13 +425,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -440,13 +440,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -5,74 +5,74 @@
     "title": "EGA sample metadata schema",
     "meta:version": "0.0.0",
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its sample metadata object. This object is intended to contain metadata about the physical sample [OBI:0000747] used in the experiment. A sample is defined as a limited quantity of something (e.g. a portion of a substance or individual) to be used for testing, analysis, inspection, investigation, demonstration, or trial use. It is a material which is collected with the intention of being representative of a greater whole. A sample shall not be confused with the individual (i.e. a person or donor) such sample derives from, for 'individual' is its own metadata object (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.individual.json). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["object_id", "organism_descriptor"],
+    "required": ["objectId", "organismDescriptor"],
     "$async": true,
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: a sample (by using EGA-sample-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: a sample (by using EGASampleIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that sample EGA ID (EGAN) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-sample-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGASampleIdPattern"
               }
             }
           }
         ]
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the sample",
         "description": "An informative sample title that should serve as an overview (e.g. sample tag, pseudonyms, sample type, sample groups, purpose...) of the sample and differentiate it from others. This short text can be used to call out sample records in searches or in displays.",
         "examples": [ "Buccal swab from COVID+ patient NM305004" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the sample",
         "description": "An informative sample description that describes the sample and differentiates it from others.",
         "examples": [ "Buccal swab from COVID positive patient (NM305004) was taken on a sunny morning, had a lower volume than expected, then was sent to..." ]
       },
 
-      "organism_descriptor": {
-        "$ref": "./EGA.common-definitions.json#/definitions/organism_descriptor"
+      "organismDescriptor": {
+        "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
       },
       
-      "sample_collection": {
+      "sampleCollection": {
         "type": "object",
         "title": "Sample collection descriptor",
-        "meta:property_curie": "OBI:0000659",
+        "meta:propertyCurie": "OBI:0000659",
         "description": "Node containing the provenance details (when and where) of the sample. This information does not include the whole sample collection protocol (expected at experiment's protocols), only the sampling date (when the sample was taken from the individual) and site (where was it taken within the individual).",
         "additionalProperties": false,
         "properties": {
-          "sample_collection_date": {
+          "sampleCollectionDate": {
             "type": "string",
             "title": "Date of the sample collection",
-            "meta:property_curie": "EFO:0000689",
+            "meta:propertyCurie": "EFO:0000689",
             "description": "Date when the sample was collected (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the collection concluded.",
             "allOf": [
               {
                 "title": "ISO8601 Date pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-ISO8601-date-pattern"
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
               }
             ]
           },
-          "age_at_collection": {
+          "ageAtCollection": {
             "type": "object",
             "title": "Individual's age at sample collection",
             "description": "Property describing the individual's age at sample collection. Can either be the precise age an age range.",
@@ -80,9 +80,9 @@
             "properties": {
               "age": {
                 "title": "Individual's age at sample collection",
-                "$ref": "./EGA.common-definitions.json#/definitions/individual-age"                
+                "$ref": "./EGA.common-definitions.json#/definitions/individualAge"                
               },
-              "age_range": {
+              "ageRange": {
                 "type": "object",
                 "title": "Individual's age range at sample collection",
                 "description": "Age range of the individual when the sample was collected. Composed of two (start and end) age points.",
@@ -90,11 +90,11 @@
                 "properties": {
                   "start": {
                     "title": "Start of the individual's age range",
-                    "$ref": "./EGA.common-definitions.json#/definitions/individual-age"
+                    "$ref": "./EGA.common-definitions.json#/definitions/individualAge"
                   },
                   "end": {
                     "title": "End of the individual's age range",
-                    "$ref": "./EGA.common-definitions.json#/definitions/individual-age"
+                    "$ref": "./EGA.common-definitions.json#/definitions/individualAge"
                   }
                 }
               }
@@ -106,27 +106,27 @@
               },
               {
                 "title": "Or the age-range is needed",
-                "required": ["age_range"]
+                "required": ["ageRange"]
               }
             ]
           },
-          "sampling_site": {
+          "samplingSite": {
             "type": "object",
             "title": "Sampling site",
             "description": "A site from which a sample, i.e. a statistically representative of the whole, is extracted from the whole.",
-            "meta:property_curie": "EFO:0000688",
+            "meta:propertyCurie": "EFO:0000688",
             "additionalProperties": false,
             "properties": {
-              "sampled_organism_part": {
+              "sampledOrganismPart": {
                 "type": "string",
                 "title": "Sampled anatomical entity (organ, tissue...)",
-                "meta:property_curie": "EFO:0000688",
+                "meta:propertyCurie": "EFO:0000688",
                 "description": "A site or entity from which a sample, i.e. a statistically representative of the whole, is extracted from the whole. The ontology to use is UBERON's anatomical entity [UBERON:0001062]. Search for your sample collection site at http://purl.obolibrary.org/obo/UBERON_0001062. For example, in the case of a nasal swab, it would be 'nasal cavity'; in a liver biopsy it would be 'liver'.",
                 "examples": ["nasal cavity", "liver", "gut wall", "oral cavity" ]
               },
-              "sampled_organism_part_curie": {
+              "sampledOrganismPartCurie": {
                 "title": "Compact URI (CURIE) of the UBERON's organism part",
-                "$ref": "./EGA.common-definitions.json#/definitions/organism-part-entity"
+                "$ref": "./EGA.common-definitions.json#/definitions/organismPartEntity"
               }
             }
           }
@@ -134,39 +134,39 @@
         "anyOf": [
           {
             "title": "Either the collection date is required",
-            "required": ["sample_collection_date"]
+            "required": ["sampleCollectionDate"]
           },
           {
             "title": "Or the age at collection is required",
-            "required": ["age_at_collection"]
+            "required": ["ageAtCollection"]
           },
           {
             "title": "Or the sampling site is required",
-            "required": ["sampling_site"]
+            "required": ["samplingSite"]
           }
         ]
       },
 
-      "sample_grouping": {
+      "sampleGrouping": {
         "type": "object",
         "title": "Sample group descriptor",
         "description": "Node describing whether the sample object is: (1) a single physical sample (a single blood sample), collected individually through its corresponding protocol; or (2) corresponds to a set of samples that, after being individually collected, was grouped together (e.g. blood samples from different donors) physically or during the experimentation and analysis. One sample corresponds to one biological replicate [EFO:0002091] (e.g. genetic content from a single cell, a tissue, buccal swab, etc.) from a single individual or from several individuals. Shall not be mistaken for technical replicates [EFO:0002090] being used several times (see https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/miscellaneous/sample_replicate.jpg).",
         "additionalProperties": false,
-        "required": ["sample_group_boolean"],
+        "required": ["sampleGroupBoolean"],
         "properties": {
-          "sample_group_boolean": {
+          "sampleGroupBoolean": {
             "type": "boolean",
             "title": "Sample group boolean",
             "description": "Boolean flag on whether the sample object is a group or an individual sample. Please note that boolean values (true or false) cannot be quoted, nor in uppercase.",
             "examples": [ true ]
           }, 
-          "sample_number": {
+          "sampleNumber": {
             "type": "integer",
             "title": "Number of samples",
             "description": "Number of individual samples (e.g. 300) encompassed by the sample group",
             "examples": [ 300 ]
           },
-          "sample_grouping_label": {
+          "sampleGroupingLabel": {
             "type": "string",
             "title": "Label of the sample grouping",
             "description": "Optional label of the sample grouping, used to add context to the group.",
@@ -175,25 +175,25 @@
         },
         "oneOf": [
           { 
-            "title": "Either the sample_number is present and above 1",
-            "required": ["sample_number"],
+            "title": "Either the sampleNumber is present and above 1",
+            "required": ["sampleNumber"],
             "properties": {
-              "sample_group_boolean": {
+              "sampleGroupBoolean": {
                 "enum": [ true ]
               },
-              "sample_number": {
+              "sampleNumber": {
                 "type": "integer",
                 "minimum": 2
               }
             }
           },
           { 
-            "title": "Or the sample_group_boolean is 'false', hence an individual sample with sample_number being '1' or no sample_number",
+            "title": "Or the sampleGroupBoolean is 'false', hence an individual sample with sampleNumber being '1' or no sampleNumber",
             "properties": {
-              "sample_group_boolean": {
+              "sampleGroupBoolean": {
                 "enum": [ false ]
               },
-              "sample_number": {
+              "sampleNumber": {
                 "enum": [ 1 ]
               }
             }
@@ -201,7 +201,7 @@
         ]
       },
 
-      "sample_types": {
+      "sampleTypes": {
         "type": "array",
         "title": "Array of sample types",
         "description": "Array of sample types: the material entity (e.g. DNA) that is this sample. Use this property as tags that befit your sample, picking as many as needed. Choose the specific terms if possible (e.g. if the assayed molecule is cDNA, add 'cDNA' instead of just 'DNA'). This property should not be confused with the sample collection protocols: regardless of the procedure to collect the sample, this property specifies what this sample is representing.",
@@ -237,11 +237,11 @@
         }        
       },
 
-      "cell_types": {
+      "cellTypes": {
         "type": "array",
         "title": "Array of cell types",
         "description": "Array of cell types, in case the sample is composed of cells (e.g. cell culture) or the cells from which the genetic material derived are known (e.g. extract DNA from astrocytes). Use this property as tags that befit your sample, picking as many cell types as your sample contains or may contain.",
-        "meta:property_curie": "EFO:0000324",
+        "meta:propertyCurie": "EFO:0000324",
         "additionalProperties": false,
         "uniqueItems": true,
         "minItems": 1,
@@ -249,10 +249,10 @@
           "type": "object",
           "title": "Cell type",
           "description": "One of the cell types that can be found in your sample or from which the genetic content was derived.",
-          "required": [ "cell_type_id", "inferred_cell_type" ],
+          "required": [ "cellTypeId", "inferredCellType" ],
           "additionalProperties": false,
           "properties": {
-            "cell_type_id": {
+            "cellTypeId": {
               "type": "string",
               "title": "Compact URI (CURIE) of the cell type",
               "graphRestriction":  {
@@ -264,17 +264,17 @@
               },
               "examples": [ "CL:0002092", "CL:0000127", "CL:0000128" ]
             },
-            "cell_type_label": {
+            "cellTypeLabel": {
               "type": "string",
               "title": "Cell type label",
               "minLength": 1,
               "examples": [ "bone marrow cell", "astrocyte", "oligodendrocyte" ]
             },
-            "inferred_cell_type": {
+            "inferredCellType": {
               "type": "string",
               "title": "Cell type label",
               "description": "A flag to specify whether the cell type classification was determined though single-cell analysis (e.g. cell clustering or trajectory analysis) or not (i.e. was visually observed or it is expected).",
-              "meta:property_curie": "EFO:0010196",
+              "meta:propertyCurie": "EFO:0010196",
               "enum": [ "inferred", "not inferred" ],
               "meta:enum": {
                 "inferred": "The cell type was inferred through single-cell analysis.",
@@ -285,11 +285,11 @@
         }
       },
 
-      "sample_status": {
+      "sampleStatus": {
         "type": "array",
         "title": "Array of sample statuses",
         "description": "Array of statuses of the sample. Used to specify the condition(s) under study **if** the diagnosis of the individual is not enough to describe the status of the sample. In other words, if the differenciation between affected and unaffected groups is done at the sample level and not at the individual level. This differentiation exists when the study design is of case-control [[EFO:0001427](http://www.ebi.ac.uk/efo/EFO_0001427)]. \nFor example, if two samples derive from an individual with 'renal cell carcinoma', one deriving from the affected tissue and the other from an unaffected tissue, this node can be used to specify whether the sample belongs to the unaffected group (i.e. control) or the affected one (i.e. case). On the other hand, if two samples derived from different probands each, one person being affected and the other unaffected by the condition under study, this node **is not** required. \nSame could be applied, for instance, for treated or untreated samples, but not for treated or untreated individuals.",
-        "meta:property_curie": "EFO:0000324",
+        "meta:propertyCurie": "EFO:0000324",
         "additionalProperties": false,
         "uniqueItems": true,
         "minItems": 1,
@@ -298,9 +298,9 @@
           "title": "Sample status item",
           "description": "One individual sample status of the array.",
           "additionalProperties": false,
-          "required": [ "case_vs_control", "condition_under_study" ],
+          "required": [ "caseVsControl", "conditionUnderStudy" ],
           "properties": {
-            "case_vs_control": {
+            "caseVsControl": {
               "type": "string",
               "title": "Case vs control",
               "description": "Property that specifies whether the sample is subject to the (usually altered) condition under study (i.e. case), or part of reference group (i.e. control). Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
@@ -312,22 +312,22 @@
               }
             },
 
-            "condition_under_study": {
+            "conditionUnderStudy": {
               "type": "object",
               "title": "Sample condition",
               "description": "One of the primary conditions under study (CUS). Notice that the sample may or may not be affected by this condition under study, belonging to the case or control groups respectively.",
-              "meta:property_curie": "NCIT:C161319",
+              "meta:propertyCurie": "NCIT:C161319",
               "additionalProperties": false,
-              "required": ["cus_curie"],
+              "required": ["cusCurie"],
               "properties": {
-                "cus_curie": {
+                "cusCurie": {
                   "type": "string",
                   "title": "Compact URI (CURIE) of the condition under study",
                   "description": "The term needs to exist within the [Ontology Lookup Service](https://www.ebi.ac.uk/ols/search?q=&groupField=iri&start=0&ontology=hp&ontology=efo&ontology=ordo&ontology=mondo) (OLS). We highly recommend the usage of the following ontologies: Experimental Factor Ontology (EFO), Human Phenotype Ontology (HP), Mondo Disease Ontology (MONDO) and Orphanet Rare Disease Ontology (ORDO).",
                   "isValidTerm": true,
                   "examples": [ "MONDO:0021354", "EFO:1002024", "MAXO:0000647", "MONDO:0005081", "MONDO:0100096" ]
                 },
-                "cus_label": {
+                "cusLabel": {
                   "type": "string",
                   "title": "Label of the condition under study",
                   "minLength": 1,
@@ -339,7 +339,7 @@
         }
       },
 
-      "sample_relationships": {
+      "sampleRelationships": {
         "type": "array",
         "title": "Sample relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. a viral sample from BioSamples being linked to a blood sample within the EGA) and within (e.g. a sample being linked to a sequencing run) the EGA.",
@@ -350,69 +350,69 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a sample",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a sample.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-assay"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         },
                         { 
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-individual"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceIndividual"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, same_as, develops_from, member_of (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, sameAs, developsFrom, memberOf (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-sample"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
                         }
                       ]
                     }
@@ -425,44 +425,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -474,11 +474,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "sample_attributes": {
+      "sampleAttributes": {
         "type": "array",
         "title": "Sample custom attributes",
         "description": "Custom attributes of a sample: reusable attributes to encode tag-value pairs (e.g. Tag being 'age' and its Value '30') with optional units (e.g. 'years'). Its properties are inherited from the common-definitions.json schema.",
@@ -486,7 +486,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -453,16 +453,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -143,10 +143,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -172,13 +172,13 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -187,13 +187,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -200,16 +200,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -6,52 +6,52 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Study metadata object. This object is intended to contain metadata about the compilation of examinations, analyses or critical inspection of a particular subject. In other words, a Study is a container of experiments and analyses of any nature (including Array data) grouped by a common goal or investigation. They often draw together data from a range of datasets and are represented in publication. For instance, an example would be a case-control study on cancer patients and healthy individuals. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/studies)",
-    "required": ["object_id", "object_title", "study_types", "study_designs"],
+    "required": ["objectId", "objectTitle", "studyTypes", "studyDesigns"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: a study (by using EGA-study-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: a study (by using EGAStudyIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that study EGA ID (EGAS) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-study-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGAStudyIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the study",
         "description": "Short free-form text that can be used to call out study records in searches or displays.",
         "examples": [ "EBI test case-control study for cancer" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the study",
         "description": "An in-depth description of the study, including its overall purpose, goals, scope or nature.",
         "examples": [ "EBI genome-wide case-control association study for Hypertension (HT) using seven disease collections together with the 1958 Spanish Birth Cohort and the EU National Blood Service collections as controls." ]
       },
 
-      "study_types": {
+      "studyTypes": {
         "type": "array",
-        "title": "Study-types array",
+        "title": "studyTypes array",
         "description": "List of study types. Contains specific keywords (e.g. 'COVID-19') as items that can be associated to the study, providing an overall view of its purpose.",
         "additionalProperties": false,
         "uniqueItems": true,
@@ -82,20 +82,20 @@
         }
       },
 
-      "study_designs": {
+      "studyDesigns": {
         "type": "array",
-        "title": "Study-designs array",
+        "title": "studyDesigns array",
         "description": "List of study designs (a.k.a. experimental designs). Contains specific keywords (e.g. 'RNA stability design') as items that can be associated to the study, providing an overall view of the method of investigating particular types of research questions or solving particular types of problems.",
         "additionalProperties": false,
         "uniqueItems": true,
         "minItems": 1,
         "items": {
           "title": "One study design",
-          "$ref": "./EGA.common-definitions.json#/definitions/study-design-keywords"
+          "$ref": "./EGA.common-definitions.json#/definitions/studyDesignKeywords"
         }
       },
 
-      "study_relationships": {
+      "studyRelationships": {
         "type": "array",
         "title": "Study relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. an ArrayExperiment being linked to a study) the EGA.",
@@ -106,60 +106,60 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a study",
               "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a study.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type referenced_by (main ones)",
+                  "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-analysis"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-experiment"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-protocol"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
                         }
                       ]
                     }
                   ]                  
                 },
                 {
-                  "title": "Allowed relationships of type grouped_with, is_after, same_as (optional ones)",
+                  "title": "Allowed relationships of type groupedWith, isAfter, sameAs (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-study"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetStudy"
                         }
                       ]
                     }
@@ -172,44 +172,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-family_relationship_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-familyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -221,11 +221,11 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/r-constraint-one-sourced-submission"
+          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
         }
       },
 
-      "study_attributes": {
+      "studyAttributes": {
         "type": "array",
         "title": "Study custom attributes",
         "description": "Custom attributes of a study: reusable attributes to encode tag-value pairs (e.g. Tag being 'Targeted loci' and its Value '5:63256183-63258334') with optional units (e.g. 'base pairs'). Its properties are inherited from the common-definitions.json schema.",
@@ -233,7 +233,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }      
     }      

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -152,10 +152,10 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },
@@ -178,10 +178,10 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
                         },
                         {
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
@@ -190,13 +190,13 @@
                           "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
                         }
                       ]
                     },

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -203,16 +203,16 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
                         }
                       ]
                     }

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -6,36 +6,36 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Submission (also known as submission project) metadata object. This object is intended to be an object that others can reference, grouping them by submission details. An EGA user can submit metadata comprising thousands of objects, or just a few that suffice the bare minimum of a comprehensive submission: at least one dataset, with its proper links to other objects. A submission JSON document hold little details, mainly the basic descriptive fields and collaborators array, but its main use is for other objects to reference it. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas).",
-    "required": ["object_id"],
+    "required": ["objectId"],
     "additionalProperties": false,
     "properties": {
-      "object_id": {
+      "objectId": {
         "type": "object",
         "title": "Object's IDs block",
-        "description": "Node containing the main identifiers of the object (e.g. alias, center_name...), inherited from the common definitions. #! We extend the core object (object_core_id) by adding a pattern check based on this schema's nature: a submission (by using EGA-submission-id-pattern)", 
+        "description": "Node containing the main identifiers of the object (e.g. alias, centerName...), inherited from the common definitions. #! We extend the core object (objectCoreId) by adding a pattern check based on this schema's nature: a submission (by using EGASubmissionIdPattern)", 
         "allOf": [
           {
-            "title": "Inherited object_core_id object",
-            "$ref": "./EGA.common-definitions.json#/definitions/object_core_id"
+            "title": "Inherited objectCoreId object",
+            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
           },
           {
             "title": "Check that Submission EGA ID (EGAB) is correct",
             "properties": {
-              "ega_accession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGA-submission-id-pattern"
+              "egaAccession": {
+                "$ref": "./EGA.common-definitions.json#/definitions/EGASubmissionIdPattern"
               }
             }
           }
         ]        
       },
 
-      "schema_descriptor": {
+      "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schema_descriptor"
+        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
       },
 
-      "object_title": {
+      "objectTitle": {
         "type": "string",
         "title": "Title of the submission project",
         "description": "Short free-form text that can be used to call out submission project records in searches or displays.",
@@ -43,7 +43,7 @@
         "examples": [ "Submission XF40" ]
       },
 
-      "object_description": {
+      "objectDescription": {
         "type": "string",
         "title": "Description of the submissions project",
         "description": "An in-depth description of the submission, including its overall purpose or nature of studies it governs.",
@@ -63,7 +63,7 @@
           "title": "Resource",
           "description": "Object defining one item of the array: an individual resource (i.e. ontology).",
           "additionalProperties": false,
-          "required": [ "name", "namespace_prefix", "version" ],
+          "required": [ "name", "namespacePrefix", "version" ],
           "properties": {
             "name": {
               "type": "string",
@@ -72,7 +72,7 @@
               "minLength": 1,
               "examples": [ "Human Phenotype Ontology", "Experimental Factor Ontology", "PubMed" ]
             },
-            "namespace_prefix": {
+            "namespacePrefix": {
               "type": "string",
               "title": "Resource namespace prefix",
               "description": "Prefixes of namespaces are used to uniquely resolve the ambiguity between identically named elements or attributes. They can easily be checked at [**identifiers.org**](https://identifiers.org/) or [**OLS' list of ontologies**](https://www.ebi.ac.uk/ols/ontologies). For example, in our example of diabetes melitus, EFO:0000400, we need both parts of the CURIE: EFO (prefix) and 0000400 (local identifier). Without knowing the prefix, the local identifier alone is difficult to resolve.",
@@ -86,7 +86,7 @@
               "minLength": 1,
               "examples": [ "2022-06-11", "3.45.0" ]
             },
-            "automatically_assigned": {
+            "automaticallyAssigned": {
               "type": "boolean",
               "title": "Automatically assigned boolean",
               "description": "Boolean switch to know if this specific resource was automatically assigned by EGA during the curation process ('true') or if it was manually given by the submitter ('false'). If this attribute is non-existent, it will also be considered to be 'false'."
@@ -95,7 +95,7 @@
         }
       },
 
-      "additional_collaborators": {
+      "additionalCollaborators": {
         "type": "array",
         "title": "Submission collaborator details",
         "description": "Object containing optional collaborators of the submission project, who shall have different capabilities granted by the owner: 'read' or 'read and write' rights.",
@@ -107,9 +107,9 @@
           "title": "Collaborator",
           "description": "Collaborator item comprising both the collaborator's contact details and rights.",
           "additionalProperties": false,
-          "required": ["collaborator_rights", "collaborator_contact_details"],      
+          "required": ["collaboratorRights", "collaboratorContactDetails"],      
           "properties": {
-            "collaborator_rights": {
+            "collaboratorRights": {
               "type": "string",
               "title": "Collaborator rights",
               "description": "Property defining the rights of the specified collaborator. Either read-only or read and write rights.",
@@ -119,14 +119,14 @@
                 "read_and_write": "Collaborator will be able to not only read, but modify or add changes to the submission."
               }
             },
-            "collaborator_contact_details": {
-              "$ref": "./EGA.common-definitions.json#/definitions/contact_details"
+            "collaboratorContactDetails": {
+              "$ref": "./EGA.common-definitions.json#/definitions/contactDetails"
             }
           }
         }
       },
 
-      "submission_relationships": {
+      "submissionRelationships": {
         "type": "array",
         "title": "Submission relationships",
         "description": "Comprises metadata (e.g. Source or Target) of a directional association between two entities. This relationships node contains all the possible relationships between metadata objects, both outside of (e.g. an Array Design Format that was submitted to ArrayExpress being linked to their microarray data within EGA) and within (e.g. a policy being linked to a submission) the EGA.",
@@ -137,35 +137,35 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationship_object"
+              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
             },
             {
               "title": "Relationship constraints for a submission",
-              "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a submission. Bare in mind that 'submissions' are referenced_by other objects, hence the relationship shall exist in their respective JSON documents.",
+              "description": "Not all possible relationships between objects are allowed (e.g. an individual should not be linked to a policy). This node contains the restricted relationships that can be given for a submission. Bare in mind that 'submissions' are referencedBy other objects, hence the relationship shall exist in their respective JSON documents.",
               "anyOf": [
                 {
-                  "title": "Allowed relationships of type same_as, grouped_with and member_of (optional ones)",
+                  "title": "Allowed relationships of type sameAs, groupedWith and memberOf (optional ones)",
                   "allOf": [
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-submission"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSubmission"
                         }
                       ]
                     }
@@ -178,41 +178,41 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-child_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-childOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-grouped_with"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-groupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-same_as"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-referenced_by"
+                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-develops_from"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-developsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-member_of"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-memberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-is_after"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-type-isAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-source-externalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_accession"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-external_URL"
+                          "$ref": "./EGA.common-definitions.json#/definitions/r-target-externalURL"
                         }
                       ]
                     }
@@ -224,7 +224,7 @@
         }
       },
 
-      "submission_attributes": {
+      "submissionAttributes": {
         "type": "array",
         "title": "Submission custom attributes",
         "description": "Custom attributes of a submission: reusable attributes to encode tag-value pairs (e.g. Tag being 'internal identifier' and its Value 'XF40') with optional units. Its properties are inherited from the common-definitions.json schema.",
@@ -232,7 +232,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/custom_attribute" 
+          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
         }
       }
     }      

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -2,48 +2,35 @@
 ## Overview
 In this directory you will find EGA's **metadata standards** or **_schemas_**: a coding system to catalogue information in structured descriptive records. These basically stablish **data elements** (_e.g._ what is ``Phenotype`` within a Sample) and the **rules** (_e.g._ if such ``Phenotype`` field can contain ``strings`` and ``integers`` or not) governing their usage to describe instances. There
 is one schema file (_e.g._ ``EGA.experiment.json``) for every metadata object (_e.g._ ``experiment``), in addition to:
-* The **common definitions** (``EGA.common-definitions.json``) contain shared nodes that other schemas can inherit. For instance, the node ``schema_descriptor`` is uniformly used by all other schemas. In order to avoid creating redundant and repeated code in each of them, we create a common "definition" of ``schema_descriptor`` within ``EGA.common-definitions.json`` that other schemas can
+* The **common definitions** (``EGA.common-definitions.json``) contain shared nodes that other schemas can inherit. For instance, the node ``schemaDescriptor`` is uniformly used by all other schemas. In order to avoid creating redundant and repeated code in each of them, we create a common "definition" of ``schemaDescriptor`` within ``EGA.common-definitions.json`` that other schemas can
 reference.
 * An **object-set** (``EGA.object-set.json``) is, simply put, an array of EGA metadata objects. In other words, a compilation of individual metadata objects (e.g. 20 ``samples``, 2 ``assays`` and 1 ``experiment`` - any combination is valid) that are validated individually. The purpose of an object-set is to avoid the need of one file per each of the metadata objects (e.g. 100 sample JSON documents
  if we were to validate 100 sample objects), being able to group them all in a single file.
-* Some **controlled vocabularies** also reside within the ``controlled_vocabulary_schemas/`` directory in a JSON schema fashion. These schemas exist so that the common definitions file is not large enough for problems viewing and editing it arise.
+* Some **controlled vocabularies** also reside within the ``controlled_vocabulary_schemas/`` directory in a JSON schema format. These schemas exist so that the common definitions file is not large enough for problems viewing and editing it arise.
 
 The current schemas are written in JavaScript Object Notation (**JSON**), providing both human- and machine-readable documentation. For further details regarding JSON-schemas visit [JSON-schema](https://json-schema.org/) and [Getting started](https://json-schema.org/learn/getting-started-step-by-step) (for an overview), or
 [Understanding JSON schema](https://json-schema.org/understanding-json-schema/) (for a detailed explanation).
 
 ## JSON Schema Validation
-In the folder [``json_validation_tests/``](../examples/json_validation_tests/) there are several ``json`` files which serve as **examples that are supposed to pass validation** (their name contains ``valid``). The current approach taken to validate JSON documents against their schemas is through **AJV command-line interface** version
-([AJV CLI v5.0.0](https://github.com/ajv-validator/ajv-cli#ajv-cli)). Each schema change in a Pull Request to ``main`` will trigger the ``json_validation`` GitHub event, which will automatically assert that these examples pass validation. In addition, one can execute AJV manually in the CLI, see as example:
-
-````bash
-schema_name="object-set"
-json_doc="object-set-valid-1.json"
-ajv --strict=false --spec=draft2019 -s "schemas/EGA.$schema_name.json" -d "examples/json_validation_tests/$json_doc" -r "schemas/EGA.!($schema_name).json" -r "schemas/controlled_vocabulary_schemas/*"
-````
-Things to notice:
-* ``--strict=false``. Given how we use custom keywords (e.g. ``meta:version``) we switch off the **strict mode** of AJV. One needs to be careful when editing the schemas: to avoid malformed keywords (e.g. ``"reqired":``) not being considered during validation one should use another type of linter.
-* ``--spec=draft2019``. The **draft** we currently use for our schemas is [**2019-09**](https://json-schema.org/draft/2019-09/release-notes.html).
-* ``-s schemas/EGA.$schema_name.json``. This specifies the **basic JSON schema** (e.g. ``EGA.object-set.json``) to validate the document against. In other words, the validator will firstly compare the document against this schema.
-* ``-r "schemas/EGA.!($schema_name).json"`` and ``-r "schemas/controlled_vocabulary_schemas/*"``. The basic JSON schema may contain references to other schemas (e.g. ``EGA.object-set.json`` using the entirety of ``EGA.sample.json``; or ``EGA.DAC.json`` using the ``schema_descriptor`` node from the common definitions). For these references to be resolved, AJV requires the file paths of all other
-schemas that may be used as references (defined by [``-r``](https://github.com/ajv-validator/ajv-cli#-r---referenced-schemas)). One could give the file paths one by one using ``-r`` repeatedly, but to simplify the command we give the full set of schemas except the basic JSON schema. To give all other schemas except the main one we use
-[glob patterns](https://github.com/isaacs/node-glob#glob-primer): ``"schemas/EGA.!($schema_name).json"`` translates into "any schema but the one containing ``$schema_name`` in its filename".
+In the folder [``json_validation_tests/``](../examples/json_validation_tests/) there are several ``json`` files which serve as **examples that are supposed to pass validation** (their name contains ``valid``). The current approach taken to validate JSON documents against their schemas is through EBI's tool [**Biovalidator**](https://github.com/elixir-europe/biovalidator)(``main`` branch). This tool is, in summary, AJV validation with extra custom keywords. This GitHub repository contains GH actions that perform validations onto the JSON test files. Check the actions [folder](../.github/workflows/) and [diagrams](../docs/gh_workflows/) for details on how local and remote validation is performed.
 
 ## Contributing to the schemas
 **Your contributions are welcomed**! If you have any ideas on how our metadata standards should improve (e.g. new fields, terms, structure...) please go to our [**contribution documentation**](../docs/contributing.md).
 
 ## Planning to modify the schemas?
 In case these schemas need to be modified, in this section you will find listed some details about the current approach that may ease the process:
+* **Naming conventions**. Properties within the JSON schemas follow SWIFT naming conventions: they are named in ``lowerCammelCase`` format. For example, ``md5ChecksumPattern`` versus ``md5_checksum_pattern``.
 * **Shared definitions**. All schemas share some fields (_e.g._ ``alias``) or patterns (_e.g._ checksum patterns) which can lead to duplicated code. In order to avoid it, we created an additional schema that corresponds to none of the EGA objects: ``EGA.common-definitions.json``. Within this file those repeated objects are specified for other schemas or objects to inherit. Based on the
 **source and target** (being the same file or another) **of the reference**, we can differentiate: (1) same-file shared definitions; (2) different-file shared definitions.
-    1. **Same-file shared definitions**. Objects within a JSON schema can be reused indefinitely. In order to do so, we stored them in the **``definitions`` anchor** (at the first level of the common schema), and then referenced them elsewhere using their relative JSON pointer (its path - _e.g._ ``"#/definitions/md5-checksum-pattern"``).
+    1. **Same-file shared definitions**. Objects within a JSON schema can be reused indefinitely. In order to do so, we stored them in the **``definitions`` anchor** (at the first level of the common schema), and then referenced them elsewhere using their relative JSON pointer (its path - _e.g._ ``"#/definitions/md5ChecksumPattern"``).
     See [Definitions](https://json-schema.org/understanding-json-schema/structuring.html#definitions) section for further details.
-    As an **example**, take a look at how we defined ``md5-checksum-pattern`` within ``definitions`` of the ``EGA.common-definitions.json``:
+    As an **example**, take a look at how we defined ``md5ChecksumPattern`` within ``definitions`` of the ``EGA.common-definitions.json``:
     ````
     # Simplified common schema:
     {
-        "$id": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json",
+        "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
         "definitions": {
-            "md5-checksum-pattern": {
+            "md5ChecksumPattern": {
                 "type": "string",
                 "pattern": "^[0-9a-z](?:-?[0-9a-z]){31}$"
             }
@@ -51,33 +38,33 @@ In case these schemas need to be modified, in this section you will find listed 
     }
    
     # When referencing the pattern:
-    { "$ref": "#/definitions/md5-checksum-pattern" }
+    { "$ref": "#/definitions/md5ChecksumPattern" }
     ````
 
-    2. **Different-file shared definitions**. The way these cross-file references are achieved is by using the IDs of the schemas (``$id`` within its first layer) and object's anchors (_e.g._ ``"EGA-sample-id-pattern``), which point to the objects within the files, turning them into references (``$ref`` wherever they are needed). References are resolved against the absolute URL identifiers of the 
-    schemas. In other words, a relative reference ($ref; e.g. ``./EGA.common-definitions.json#...``) is put against the absolute identifier (``$id``; e.g. ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json``) of the referencing schema (in this example ``EGA.analysis.json``), transforming the relative reference into an absolute one (e.g. 
+    2. **Different-file shared definitions**. The way these cross-file references are achieved is by using the IDs of the schemas (``$id`` within its first layer) and object's anchors (_e.g._ ``"EGASampleIdPattern``), which point to the objects within the files, turning them into references (``$ref`` wherever they are needed). References are resolved against the absolute URL identifiers of the 
+    schemas. In other words, a relative reference ($ref; e.g. ``./EGA.common-definitions.json#...``) is resolved against the absolute identifier (``$id``; e.g. ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json``) of the referencing schema (in this example ``EGA.analysis.json``), transforming the relative reference into an absolute one (e.g. 
     ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json#...``). See 
-    [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``object_coreIDs`` within ``definitions`` of the ``EGA.common-definitions.json`` and then referenced it within the ``experiment.json`` (notice how this time the JSON 
+    [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``objectCoreId`` within ``definitions`` of the ``EGA.common-definitions.json`` and then referenced it within the ``EGA.experiment.json`` (notice how this time the JSON 
     pointer contains the whole ``$id`` instead of being relative):
     ````
     # Simplified common schema
     {
         "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
         "definitions": {
-            "object_coreIDs": {
+            "objectCoreId": {
                 ...
             }
     }
 
-    # Simplified experiment schema with a reference to the object_coreIDs:
+    # Simplified experiment schema with a reference to the objectCoreId:
     {
         "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.experiment.json",
         "properties": {
-            "object_ids": {
+            "objectId": {
                 "type": "object",
                 "allOf": [
                     {
-                        "$ref": "./EGA.common-definitions.json#/definitions/object_coreIDs"
+                        "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
                     }
                 ]
             }


### PR DESCRIPTION
## Ticket reference
EEH-2468

## Overall changes
- Refactored JSON schemas to have properties in ``lowerCamelCase`` instead of the previous heterogeneous ``snake_case``. 
- Amended the JSON documents with these new naming conventions.
- Updated schemas' README.

## Future TO-DOs
- NA.
