### PR TITLE
EEH-2470 - Quickfix after Biovalidator's improvements

### DIFF
--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -110,7 +110,7 @@
                 "additionalProperties": false,
                 "uniqueItems": true,
                 "items": { 
-                  "$ref": "./EGA.common-definitions.json#/definitions/sampleLabel-association"
+                  "$ref": "./EGA.common-definitions.json#/definitions/sampleLabelAssociation"
                 }
               }
             },

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -3254,7 +3254,7 @@
         "type": "string",
         "title": "Compact URI (CURIE) of the UBERON's organism part",
         "meta:propertyCurie": "EFO:0000635",
-        "description": "The part of organism's anatomy or substance arising from an organism from which the biomaterial was derived, excludes cells. E.g. tissue, organ, system, sperm, blood or body location (arm). Search for yours at: http://www.ebi.ac.uk/efo/EFO_0000635. This property can be used to describe a sampling site or the morphological site of a disease, for example.",
+        "description": "The part of organism's anatomy or substance arising from an organism from which the biomaterial was derived, excludes cells. E.g. tissue, organ, system, sperm, blood or body location (arm). Search for yours at: http://purl.obolibrary.org/obo/UBERON_0000061. This property can be used to describe a sampling site or the morphological site of a disease, for example.",
         "allOf": [
           {
             "title": "General CURIE pattern",
@@ -3262,8 +3262,8 @@
           }
         ],
         "graphRestriction":  {
-          "ontologies" : ["obo:efo"],
-          "classes": ["EFO:0000635"],
+          "ontologies" : ["obo:uberon"],
+          "classes": ["UBERON:0000061"],
           "relations": ["rdfs:subClassOf"],
           "direct": false,
           "include_self": false

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -323,8 +323,7 @@
                 "cusCurie": {
                   "type": "string",
                   "title": "Compact URI (CURIE) of the condition under study",
-                  "description": "The term needs to exist within the [Ontology Lookup Service](https://www.ebi.ac.uk/ols/search?q=&groupField=iri&start=0&ontology=hp&ontology=efo&ontology=ordo&ontology=mondo) (OLS). We highly recommend the usage of the following ontologies: Experimental Factor Ontology (EFO), Human Phenotype Ontology (HP), Mondo Disease Ontology (MONDO) and Orphanet Rare Disease Ontology (ORDO).",
-                  "isValidTerm": true,
+                  "description": "The term should exist within the [Ontology Lookup Service](https://www.ebi.ac.uk/ols/search?q=&groupField=iri&start=0&ontology=hp&ontology=efo&ontology=ordo&ontology=mondo) (OLS). We highly recommend the usage of the following ontologies: Experimental Factor Ontology (EFO), Human Phenotype Ontology (HP), Mondo Disease Ontology (MONDO) and Orphanet Rare Disease Ontology (ORDO).",
                   "examples": [ "MONDO:0021354", "EFO:1002024", "MAXO:0000647", "MONDO:0005081", "MONDO:0100096" ]
                 },
                 "cusLabel": {


### PR DESCRIPTION
## Ticket reference
EEH-2470

## Overall changes
- Amended one missing camelized word
- Changed a restriction within cusCurie, which was technically for IRIs but I intended for it to be used with CURIEs
- Changed the ontology from EFO to UBERON in anatomical entity, since EFO has a duplicated entity (see reported issue: https://github.com/EBISPOT/efo/issues/1863)

## Future TO-DOs
- NA
