### PR TITLE
EE-2627_minorFix - Fixed a minor error in a JSON example

### DIFF
--- a/examples/json_validation_tests/analysis_valid-1.json
+++ b/examples/json_validation_tests/analysis_valid-1.json
@@ -122,8 +122,10 @@
                 "lociDescriptor": [
                     {
                         "geneDescriptor": {
-                            "termId": "HGNC:11998",
-                            "termLabel": "TP53"
+                            "geneIdentifier": {
+                                "termId": "HGNC:11998",
+                                "termLabel": "TP53"
+                            }
                         },
                         "locusAdditionalDescription": "Variation within the VCF corresponds to TP53 variation among patients."
                     }


### PR DESCRIPTION
After merging I was able to bypass error https://github.com/elixir-europe/biovalidator/issues/57, as expected, and thus I was able to test validation. 

## Ticket reference
EE-2627

## Overall changes
- Added geneIdentifier where it was missing in one of the examples.

## Future TO-DOs
- NA
