### PR TITLE
EE-2454 - Added Single Cell Sequencing example

### DIFF
--- a/examples/json_validation_tests/object-set_SingleCellSequencing.json
+++ b/examples/json_validation_tests/object-set_SingleCellSequencing.json
@@ -4,7 +4,7 @@
     },
     "data": {
         "objectTitle": "Example of a Single Cell Sequencing minimal submission",
-        "objectDescription": "This object-set constitutes an example of all objects one would expect in a SCS submission. For example, a few samples, the individuals they derive from, the assays... It is inspired in the SC RNASeq tutorial: https://hbctraining.github.io/scRNA-seq/lessons/pseudobulk_DESeq2_scrnaseq.html",
+        "objectDescription": "This object-set constitutes an example of some objects one would expect in a minimal Single Cell Sequencing (SCS) submission: an individual (from which 2 samples were derived); physical samples (blood samples, not individual cells); an experiment compiling the protocols performed over the samples; and the resulting assays containing the raw and sequencing files. There are many other objects one would submit for a full SCS submission: a policy, DAC and dataset to specify the reusability of the data; a study highlighting the aims and topics of the submission; analyses containing the bioinformatics investigations over the raw files; protocols describing each of the procedures performed (from sample collection to differential expression); and finally a submission which would be referenced by all objects. This minimal objects are inspired in the SC RNASeq tutorial: https://hbctraining.github.io/scRNA-seq/lessons/pseudobulk_DESeq2_scrnaseq.html",
         "objectArray": [
             
             {

--- a/examples/json_validation_tests/object-set_SingleCellSequencing.json
+++ b/examples/json_validation_tests/object-set_SingleCellSequencing.json
@@ -1,0 +1,548 @@
+{
+    "schema": {
+        "$ref": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.object-set.json"
+    },
+    "data": {
+        "objectTitle": "Example of a Single Cell Sequencing minimal submission",
+        "objectDescription": "This object-set constitutes an example of all objects one would expect in a SCS submission. For example, a few samples, the individuals they derive from, the assays... It is inspired in the SC RNASeq tutorial: https://hbctraining.github.io/scRNA-seq/lessons/pseudobulk_DESeq2_scrnaseq.html",
+        "objectArray": [
+            
+            {
+                "objectId": {
+                    "alias": "NM305004-PBMC_Sample_treated",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "PBMC sample - Lupus treated",
+                "objectDescription": "Peripheral Blood Mononuclear Cells (PBMC) sample from individual with lupus.",
+                "organismDescriptor": {
+                    "organismTaxon": {
+                        "termId": "NCBITaxon:9606",
+                        "termLabel": "homo sapiens"
+                    },
+                    "commonName": "human"
+                },
+                "sampleCollection": {
+                    "ageAtCollection": {
+                        "age": "P10Y6M"
+                    },
+                    "samplingSite": {
+                        "termId": "UBERON:0001414",
+                        "termLabel": "median basilic vein"
+                    }
+                },
+                "sampleStatus": [
+                    {
+                        "caseVsControl": "case",
+                        "conditionUnderStudy": {
+                            "termId": "EFO:0003023",
+                            "termLabel": "Activated by 100 U/mL of recombinant IFN-β for 6 hours"
+                        }
+                    }
+                ],
+                "sampleTypes": [
+                    "cell culture"
+                ],
+                "cellTypes": [
+                    {
+                        "cellType": {
+                            "termId": "CL:0000236",
+                            "termLabel": "B cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000624",
+                            "termLabel": "CD4-positive, alpha-beta T cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000625",
+                            "termLabel": "CD8-positive, alpha-beta T cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000623",
+                            "termLabel": "natural killer cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000576",
+                            "termLabel": "Monocyte"
+                        },
+                        "cellTypeInferred": "inferred",
+                        "cellTypeLabel": "FCGR3A+"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0001054",
+                            "termLabel": "CD14-positive monocyte"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000451",
+                            "termLabel": "Dendritic cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000556",
+                            "termLabel": "Megakaryocyte"
+                        },
+                        "cellTypeInferred": "inferred"
+                    }
+                ],
+                "sampleRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAI00000000001"
+                            },
+                            "objectType": "individual"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Sample collection protocol",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "IFN-Beta sample treatment",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00000000001"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referencedBy"
+                    }
+                ],
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "sample"
+                }
+            },
+            {
+                "objectId": {
+                    "alias": "NM305004-PBMC_Sample_Untreated",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "PBMC sample - Lupus untreated",
+                "objectDescription": "Peripheral Blood Mononuclear Cells (PBMC) sample from individual with lupus.",
+                "organismDescriptor": {
+                    "organismTaxon": {
+                        "termId": "NCBITaxon:9606",
+                        "termLabel": "homo sapiens"
+                    },
+                    "commonName": "human"
+                },
+                "sampleCollection": {
+                    "ageAtCollection": {
+                        "age": "P10Y6M"
+                    },
+                    "samplingSite": {
+                        "termId": "UBERON:0001414",
+                        "termLabel": "median basilic vein"
+                    }
+                },
+                "sampleStatus": [
+                    {
+                        "caseVsControl": "control",
+                        "conditionUnderStudy": {
+                            "termId": "EFO:0003023",
+                            "termLabel": "Activated by 100 U/mL of recombinant IFN-β for 6 hours"
+                        }
+                    }
+                ],
+                "sampleTypes": [
+                    "cell culture"
+                ],
+                "cellTypes": [
+                    {
+                        "cellType": {
+                            "termId": "CL:0000236",
+                            "termLabel": "B cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000624",
+                            "termLabel": "CD4-positive, alpha-beta T cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000625",
+                            "termLabel": "CD8-positive, alpha-beta T cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000623",
+                            "termLabel": "natural killer cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000576",
+                            "termLabel": "Monocyte"
+                        },
+                        "cellTypeInferred": "inferred",
+                        "cellTypeLabel": "FCGR3A+"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0001054",
+                            "termLabel": "CD14-positive monocyte"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000451",
+                            "termLabel": "Dendritic cell"
+                        },
+                        "cellTypeInferred": "inferred"
+                    },
+                    {
+                        "cellType": {
+                            "termId": "CL:0000556",
+                            "termLabel": "Megakaryocyte"
+                        },
+                        "cellTypeInferred": "inferred"
+                    }
+                ],
+                "sampleRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAI00000000001"
+                            },
+                            "objectType": "individual"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Sample collection protocol",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00000000001"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referencedBy"
+                    }
+                ],
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.sample.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "sample"
+                }
+            },
+            {
+                "objectId": {
+                    "alias": "SCS_rnaseq",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Single Cell Sequencing of Lupus Tissue to Identify Cell Subpopulations and Pathogenic Mechanisms",
+                "objectDescription": "This single cell sequencing experiment utilizes the Illumina NextSeq 500 platform and the 10x Genomics library to analyze the cellular heterogeneity of lupus. The high-throughput capabilities of the NextSeq 500 and the improved resolution of the 10x Genomics library allow for the detailed analysis of specific cell subpopulations and the identification of potential pathogenic mechanisms in lupus. The results of this experiment may inform the development of targeted therapies for this autoimmune disease.",
+                "assayTechnology": {
+                    "assayInstrument": "sequencer",
+                    "assayInstrumentPlatform": "Illumina NextSeq 500"
+                },
+                "assayTypeDescriptor": {
+                    "assayType": "assay by high throughput sequencer",
+                    "assaySubtype": "single cell sequencing"
+                },
+                "assayedMoleculeType": "RNA",
+                "typesOfOutputData": [
+                    "transcriptomic data"
+                ],
+                "experimentTypeSpecifications": {
+                    "sequencingExperiment": {
+                        "libraryLayout": "paired-end"
+                    }
+                },
+                "experimentRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAS00000000001"
+                            },
+                            "objectType": "study"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rTarget": {
+                            "objectId": {
+                                "egaAccession": "EGAZ00000000001"
+                            },
+                            "objectType": "analysis"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Library preparation 10X Genomics",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Sequencing protocol",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "Sample demultiplexing",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "protocol"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00000000001"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referencedBy"
+                    }
+                ],
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.experiment.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "experiment"
+                }
+            },
+            {
+                "objectId": {
+                    "alias": "SCS_Assay - Untreated sample",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Single Cell Sequencing Assay 1 - Untreated sample",
+                "assayCenter": "EBI-TEST",
+                "assayDate": "2022-02-13",
+                "assayTypeSpecifications": {
+                    "assayType": "sequencing",
+                    "sequencingAssaySpecifications": {
+                        "referenceAlignmentDetails": [
+                            {
+                                "ncbiAssembly": {
+                                    "termId": "assembly:GCF_000001405.26",
+                                    "termLabel": "GRCh38.p14"
+                                }
+                            }
+        
+                        ]
+                    }
+                },
+                "assayFiles": [
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "db75a499836cd430cc9d25b5f89ea4c3",
+                        "filename": "unaligned_reads_ot_untreated_sample.fastq.gpg",
+                        "filetype": "FASTQ",
+                        "unencryptedChecksum": "dc2f2f3aa81f299944e23aacf5a40b2c"
+                    },
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "fdbfd70466017e8387bc55c65b553b2b",
+                        "filename": "aligned_reads_ot_untreated_sample.cram.gpg",
+                        "filetype": "CRAM",
+                        "unencryptedChecksum": "66526ffc57804187654eba000bc3905c"
+                    }
+                ],
+                "assayRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "NM305004-PBMC_Sample_Untreated",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "sample"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAX00000000001"
+                            },
+                            "objectType": "experiment"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rTarget": {
+                            "objectId": {
+                                "egaAccession": "EGAZ00000000001"
+                            },
+                            "objectType": "analysis"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00000000001"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referencedBy"
+                    }
+                ],
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "assay"
+                }
+            },
+            {
+                "objectId": {
+                    "alias": "SCS_Assay - Treated sample",
+                    "centerName": "EBI-TEST"
+                },
+                "objectTitle": "Single Cell Sequencing Assay 1 - Treated sample",
+                "assayCenter": "EBI-TEST",
+                "assayDate": "2022-02-13",
+                "assayTypeSpecifications": {
+                    "assayType": "sequencing",
+                    "sequencingAssaySpecifications": {
+                        "referenceAlignmentDetails": [
+                            {
+                                "ncbiAssembly": {
+                                    "termId": "assembly:GCF_000001405.26",
+                                    "termLabel": "GRCh38.p14"
+                                }
+                            }
+        
+                        ]
+                    }
+                },
+                "assayFiles": [
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "4f254fb40667afec9bc7d98085dea53c",
+                        "filename": "unaligned_reads_ot_treated_sample.fastq.gpg",
+                        "filetype": "FASTQ",
+                        "unencryptedChecksum": "bcb4d19c09bd5463bddb01ec8aae8d63"
+                    },
+                    {
+                        "checksumMethod": "MD5",
+                        "encryptedChecksum": "d82c00a086dd492978ead392cfd8335f",
+                        "filename": "aligned_reads_ot_treated_sample.cram.gpg",
+                        "filetype": "CRAM",
+                        "unencryptedChecksum": "8033f2e64be1d2585d733fd92d0009af"
+                    }
+                ],
+                "assayRelationships": [
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "alias": "NM305004-PBMC_Sample_treated",
+                                "centerName": "EBI-TEST"
+                            },
+                            "objectType": "sample"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAX00000000001"
+                            },
+                            "objectType": "experiment"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rTarget": {
+                            "objectId": {
+                                "egaAccession": "EGAZ00000000001"
+                            },
+                            "objectType": "analysis"
+                        },
+                        "rType": "referencedBy"
+                    },
+                    {
+                        "rSource": {
+                            "objectId": {
+                                "egaAccession": "EGAB00000000001"
+                            },
+                            "objectType": "submission"
+                        },
+                        "rType": "referencedBy"
+                    }
+                ],
+                "schemaDescriptor": {
+                    "commonSchemaVersion": "0.0.0",
+                    "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.assay.json",
+                    "objectSchemaVersion": "0.0.0",
+                    "objectType": "assay"
+                }
+            }            
+        ],
+        "schemaDescriptor": {
+            "commonSchemaVersion": "0.0.0",
+            "describedBySchemaUri": "https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.object-set.json",
+            "objectSchemaVersion": "0.0.0",
+            "objectType": "object-set"
+        }
+    }
+}

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -78,7 +78,7 @@
           "assayType": {
             "type": "string",
             "title": "Type of the assay",
-            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
+            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
             "anyOf": [
               {
                 "title": "Array-assay type controlled vocabulary (CV) list",
@@ -94,7 +94,7 @@
           "assaySubtype": {
             "type": "string",
             "title": "Subtype of the assay",
-            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_dna.json))",
+            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json))",
             "examples": [ "MC-4C", "UMI-4C", "single nucleus RNA sequencing", "RNA-seq of coding RNA from single cells", "Quant-seq", "DNA-seq", "ATAC-seq", "DNase Hi-C", "scDNase-seq", "in situ HiC", "exome sequencing" ]
           }
         },

--- a/schemas/EGA.object-set.json
+++ b/schemas/EGA.object-set.json
@@ -5,10 +5,27 @@
     "title": "EGA object-set metadata schema",
     "meta:version": "0.0.0",
     "$async": true,
-    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate an object set. A set or group of objects is defined as an array of individual objects (e.g. 'sample' or 'experiment'). The minimum length of the array is 1 (i.e. it has to contain at least one object). These objects can be of different nature, and are validated against their corresponding schemas based on the 'schemaDescriptor' node within each individual object, which specifies the schema against the individual object needs to be validated. To put it simply, this object-set schema exists to avoid the need of 1 single file per each object: for a submission of 1000 samples we would require 1000 JSON files, each of them corresponding to one of the objects; whereas using an object-set allows us to fit all those objects together in a single file. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
+    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate an object-set. A set or group of objects is defined as an array of individual objects (e.g. 'sample' or 'experiment'). The minimum length of the array is 1 (i.e. it has to contain at least one object). These objects can be of different nature, and are validated against their corresponding schemas based on the 'schemaDescriptor' node within each individual object, which specifies the schema against the individual object needs to be validated. Notice how this schema is missing the basic 'objectId' of other objects, since an object-set is not an object per se, it is just a compilation of objects. To put it simply, this object-set schema exists to avoid the need of 1 single file per each object: for a submission of 1000 samples we would require 1000 JSON files, each of them corresponding to one of the objects; whereas using an object-set allows us to fit all those objects together in a single file. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
     "required": ["objectArray"],
     "additionalProperties": false,
     "properties": {
+
+      "objectTitle": {
+        "type": "string",
+        "title": "Title of the object-set",
+        "description": "Free-form title of the object-set. Used as a convenient way to identify different object-sets.",
+        "examples": [ "Example of Single Cell Sequencing", "myObjectSet_2" ]
+      },
+
+      "objectDescription": {
+        "type": "string",
+        "title": "Description of the object-set",
+        "description": "More extensive free-form description of the object-set. Used to provide context on why the items (i.e. individual objects) of the array are grouped together.",
+        "examples": [ 
+          "This object-set corresponds to a whole example of a Single Cell Sequencing submission, being grouped together and submitted together.",
+          "When submitting the previous object set, 4 samples were wrong and need to be re-submitted, and that's the purpose of this object-set."
+        ]
+      },
 
       "schemaDescriptor": {
         "title": "Schema descriptor node",

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -257,6 +257,13 @@
                 "inferred": "The cell type was inferred through single-cell analysis.",
                 "not inferred": "The cell type was not inferred through single-cell analysis (i.e. it was asserted to be in the sample)."
               }
+            },
+            "cellTypeLabel": {
+              "type": "string",
+              "title": "Label of the cell type",
+              "description": "A field to add extra context to the cell type. For example, the expression profile (e.g. FCGR3A+) used to distinguish within the cell group or the morphology. Only advised to be used when the ontology term for the cell type is not granular enough. Otherwise, the most granular ontology term for the cell type should be used.",
+              "minLength": 1,
+              "examples": [ "FCGR3A+ Monocytes", "TUNEL-positive ACE2-positive neurons" ]
             }
           }          
         }


### PR DESCRIPTION
## Ticket reference
EE-2454

## Overall changes
- Modified the Sample schema to have a cell type label (to define the characterization of cells when the ontologies are not enough - e.g. Positive in these genes, but not these...)
- Modified a few broken URLS in the Experiment schema
- Modified the object-set schema to allow for an object title and description, so that some context can be given on why those objects are grouped together.
- Finally added an SCS example of an object-set, minimal with an individual object, 2 samples, 1 experiment and 2 sequencing assays.

## Future TO-DOs
- [ ] Given that Biovalidator keeps giving us problems when launched locally, I couldn't fully validate that the example is correct. Only when the schema changes are merged and we fetch them (which currently gives less issues) I'll be able to know more errors if any.
