### PR TITLE
EEH-2488 - Gotten rid of the ``controlled_vocabulary_schemas``

### DIFF
--- a/examples/json_validation_tests/assay_valid-1_array.json
+++ b/examples/json_validation_tests/assay_valid-1_array.json
@@ -50,6 +50,7 @@
             }
         ],
         "assayTypeSpecifications": {
+            "assayInstrument": "array",
             "arrayAssaySpecifications": {
                 "arraySampleLabels": [
                     {
@@ -76,8 +77,7 @@
                     }
                 ],
                 "nLabelsPerArray": 2
-            },
-            "assayType": "array"
+            }
         },
         "objectId": {
             "alias": "My_array_assay_M3051057",

--- a/examples/json_validation_tests/assay_valid-2_sequencing.json
+++ b/examples/json_validation_tests/assay_valid-2_sequencing.json
@@ -59,7 +59,7 @@
             }
         ],
         "assayTypeSpecifications": {
-            "assayType": "sequencing",
+            "assayInstrument": "sequencer",
             "sequencingAssaySpecifications": {
                 "referenceAlignmentDetails": [
                     {

--- a/examples/json_validation_tests/experiment_valid-1.json
+++ b/examples/json_validation_tests/experiment_valid-1.json
@@ -4,8 +4,9 @@
             "assayInstrument": "array",
             "assayInstrumentPlatform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
         },
-        "assayTypeDescriptor": {
-            "assayType": "ChIP-chip by SNP array"
+        "assayType": {
+            "termId": "EFO:0002764",   
+            "termLabel": "ChIP-chip by SNP array"
         },
         "assayedMoleculeType": "DNA",
         "experimentAttributes": [

--- a/examples/json_validation_tests/object-set_valid-1.json
+++ b/examples/json_validation_tests/object-set_valid-1.json
@@ -6,8 +6,9 @@
                     "assayInstrument": "array",
                     "assayInstrumentPlatform": "[HuGene-2_0-st] Affymetrix Human Gene 2.0 ST Array [transcript (gene) version]"
                 },
-                "assayTypeDescriptor": {
-                    "assayType": "ChIP-chip by SNP array"
+                "assayType": {
+                    "termId": "EFO:0002764",   
+                    "termLabel": "ChIP-chip by SNP array"
                 },
                 "assayedMoleculeType": "DNA",
                 "experimentAttributes": [

--- a/examples/json_validation_tests/object-set_valid-1.json
+++ b/examples/json_validation_tests/object-set_valid-1.json
@@ -239,7 +239,7 @@
                     }
                 ],
                 "assayTypeSpecifications": {
-                    "assayType": "sequencing",
+                    "assayInstrument": "sequencer",
                     "sequencingAssaySpecifications": {
                         "referenceAlignmentDetails": [
                             {
@@ -327,6 +327,7 @@
                     }
                 ],
                 "assayTypeSpecifications": {
+                    "assayInstrument": "array",
                     "arrayAssaySpecifications": {
                         "arraySampleLabels": [
                             {
@@ -349,8 +350,7 @@
                             }
                         ],
                         "nLabelsPerArray": 2
-                    },
-                    "assayType": "array"
+                    }
                 },
                 "objectId": {
                     "alias": "My_array_assay_M3051057",

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -117,58 +117,43 @@
             "anyOf": [
               {
                 "title": "2 labels per array check",
-                "description": "If two labels were used per array, the sampleLabel specifications will be expected and at least 2 items (one for each label)",
-                "if": {
-                  "required": [ "nLabelsPerArray" ],
-                  "properties": {
-                    "prueba": { "const": 2 }
-                  }
-                },
-                "then": { 
-                  "required": [ "arraySampleLabels" ],
-                  "properties": {
-                    "arraySampleLabels": {
-                      "minItems": 2
-                    }
+                "description": "If 2 labels were used per array, the sampleLabel specifications will be expected and at least 2 items (one for each label)",
+                "required": [ "nLabelsPerArray", "arraySampleLabels" ],
+                "properties": {
+                  "nLabelsPerArray": { 
+                    "const": 2 
+                  },
+                  "arraySampleLabels": {
+                    "minItems": 2
                   }
                 }
               },
               {
                 "title": "3 labels per array check",
-                "description": "If three labels were used per array, the sampleLabel specifications will be expected and at least 3 items (one for each label)",
-                "if": {
-                  "required": [ "nLabelsPerArray" ],
-                  "properties": {
-                    "prueba": { "const": 3 }
-                  }
-                },
-                "then": { 
-                  "required": [ "arraySampleLabels" ],
-                  "properties": {
-                    "arraySampleLabels": {
-                      "minItems": 3
-                    }
+                "description": "If 3 labels were used per array, the sampleLabel specifications will be expected and at least 3 items (one for each label)",
+                "required": [ "nLabelsPerArray", "arraySampleLabels" ],
+                "properties": {
+                  "nLabelsPerArray": { 
+                    "const": 3 
+                  },
+                  "arraySampleLabels": {
+                    "minItems": 3
                   }
                 }
               },
               {
                 "title": "4 labels per array check",
-                "description": "If four labels were used per array, the sampleLabel specifications will be expected and at least 4 items (one for each label)",
-                "if": {
-                  "required": [ "nLabelsPerArray" ],
-                  "properties": {
-                    "prueba": { "const": 4 }
-                  }
-                },
-                "then": { 
-                  "required": [ "arraySampleLabels" ],
-                  "properties": {
-                    "arraySampleLabels": {
-                      "minItems": 4
-                    }
+                "description": "If 4 labels were used per array, the sampleLabel specifications will be expected and at least 4 items (one for each label)",
+                "required": [ "nLabelsPerArray", "arraySampleLabels" ],
+                "properties": {
+                  "nLabelsPerArray": { 
+                    "const": 4 
+                  },
+                  "arraySampleLabels": {
+                    "minItems": 4
                   }
                 }
-              }              
+              }           
             ]
           },
           "sequencingAssaySpecifications": {

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -69,18 +69,18 @@
       "assayTypeSpecifications": {
         "type": "object",
         "title": "Assay type specifications",
-        "description": "Node containing different sets of fields that depend on the specific assay type. The main categories of assay types follow a similar pattern as the used technology: either array assays (those in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used) or sequencing assays (those in which a [sequencing instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used). Depending on the used technology, different types of fields will be required. For example, if an array was used, its sample_arrayLabels will be expected. Having this modular assay type-related node allows for easy additions of new technology-specific requirements.",
+        "description": "Node containing different sets of fields that depend on the instrument used for the assay: either array assays (those in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used) or sequencing assays (those in which a [sequencing instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used). Depending on the used technology, different types of fields will be required. For example, if an array was used, its arraySampleLabels will be expected. Having this modular assay type-related node allows for easy additions of new technology-specific requirements.",
         "additionalProperties": false,
-        "required": ["assayType"],
+        "required": ["assayInstrument"],
         "properties": {
-          "assayType": {
+          "assayInstrument": {
             "type": "string",
             "title": "Assay type",
             "description": "The general categories, either sequencing or array, in which assays are categorized based on the used instruments. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
-            "enum": ["array", "sequencing"],
+            "enum": ["array", "sequencer"],
             "meta:enum": {
               "array": "An assay in which an [array instrument [EFO:0002698]](http://www.ebi.ac.uk/efo/EFO_0002698) was used.",
-              "sequencing": "An assay in which a [sequencer instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used."
+              "sequencer": "An assay in which a [sequencer instrument [EFO:0003739]](http://www.ebi.ac.uk/efo/EFO_0003739) was used."
             }
           },
           "arrayAssaySpecifications": {
@@ -159,7 +159,7 @@
           "sequencingAssaySpecifications": {
             "type": "object",
             "title": "Specifications of a sequencing assay",
-            "description": "Node containing the set of fields specific to an assay of type 'sequencing' (i.e. a sequencer was used to obtain the raw data).",
+            "description": "Node containing the set of fields specific to an assay of type 'sequencer' (i.e. a sequencer was used to obtain the raw data).",
             "additionalProperties": false,
             "properties": {
               "referenceAlignmentDetails": {
@@ -174,9 +174,9 @@
           {
             "title": "If the assay is of type array its specifications will be expected",
             "if": {
-              "required": ["assayType"],
+              "required": ["assayInstrument"],
               "properties": {
-                "assayType": {
+                "assayInstrument": {
                       "enum": ["array"]
                 }
               }
@@ -389,8 +389,8 @@
           "properties": {
             "assayTypeSpecifications": {
               "properties": {
-                "assayType": {
-                  "const": "sequencing"
+                "assayInstrument": {
+                  "const": "sequencer"
                 }
               }
             }
@@ -416,7 +416,7 @@
           "properties": {
             "assayTypeSpecifications": {
               "properties": {
-                "assayType": {
+                "assayInstrument": {
                   "const": "array"
                 }
               }

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -2916,7 +2916,7 @@
             "type": "string",
             "title": "Assay's instrument category",
             "meta:propertyCurie": "EFO:0002773",
-            "description": "The general categories (e.g. sequencers) in which assay instruments are categorized. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
+            "description": "The general categories (e.g. sequencer) in which assay instruments are categorized. Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
             "enum": [ "array", "sequencer" ],
             "meta:enum": {
               "array": "[EFO:0002698][Array instrument](http://www.ebi.ac.uk/efo/EFO_0002698), an instrument which consists of nucleic acid or protein molecules bound to a substrate",
@@ -2925,36 +2925,12 @@
           },
           "assayInstrumentPlatform": {
             "type": "string",
-            "title": "Assay instrument label",
-            "description": "Label (e.g. 'Illumina HiSeq 2500'), chosen from a list of controlled vocabulary (CV), of the technology used at the experiment. If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
+            "title": "Assay instrument platform",
+            "description": "Platform of the used instrument (e.g. 'Illumina HiSeq 2500'). Given the heterogenity in sequencing and array platforms (power of thousands), this property is not restricted by a CV list (i.e. it is free text).",
             "minLength": 1,
             "examples": ["Illumina HiSeq 2500", "[HuGene-1_1-st] Affymetrix Human Gene 1.1 ST Array [probe set (exon) version]", "DNBSEQ-G400 FAST"]
           }
-        },
-        "oneOf": [
-          {
-            "title": "Asserting array technology controlled vocabulary (CV)",
-            "properties": {
-              "assayInstrument": {
-                "enum": [ "array" ]
-              },
-              "assayInstrumentPlatform": {
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_array.json"
-              }
-            }              
-          },
-          {
-            "title": "Asserting sequencer technology controlled vocabulary (CV)",
-            "properties": {
-              "assayInstrument": {
-                "enum": [ "sequencer" ]
-              },
-              "assayInstrumentPlatform": {
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.instrument_platforms_sequencing.json"
-              }
-            }              
-          }
-        ]
+        }
       },
 
       "libraryLayout": {

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -6,7 +6,7 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its experiment metadata object. An experiment is considered a planned and intentionally designed process performed as part of a study. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["objectId", "assayTechnology", "assayType", "assayedMoleculeType", "experimentTypeSpecifications"],
+    "required": ["objectId", "assayTechnology", "assayType", "assayedBiologicalMacromolecule", "experimentTypeSpecifications"],
     "additionalProperties": false,
     "properties": {
       "objectId": {
@@ -88,7 +88,7 @@
                   "ontologies" : ["obo:efo"],
                   "classes": ["EFO:0003740"],
                   "relations": ["rdfs:subClassOf"],
-                  "direct": true,
+                  "direct": false,
                   "include_self": false
                 }
               },
@@ -98,7 +98,7 @@
                   "ontologies" : ["obo:efo"],
                   "classes": ["EFO:0002696"],
                   "relations": ["rdfs:subClassOf"],
-                  "direct": true,
+                  "direct": false,
                   "include_self": false
                 }
               }
@@ -122,7 +122,6 @@
         "properties": {        
           "termId": {
             "title": "Ontology constraints for this specific termId",
-            "description": "",
             "graphRestriction ":  {
               "ontologies" : ["obo:efo"],
               "classes": ["EFO:0004446"],
@@ -405,6 +404,94 @@
           }
         }
       }
-    ]
-      
+    ],
+
+    "allOf": [
+      {
+        "title": "If the assayed molecule is 'deoxyribonucleic acid' then, the assay type must be of 'DNA asay' type",
+        "if": {
+          "required": ["assayedBiologicalMacromolecule"],
+          "properties": {
+            "assayedBiologicalMacromolecule": {
+              "required": ["termId"],
+              "properties": {
+                "termId": {
+                  "title": "Ontology constraint for 'deoxyribonucleic acid'",
+                  "graphRestriction ":  {
+                    "ontologies" : ["obo:efo"],
+                    "classes": ["CHEBI:16991"],
+                    "relations": ["rdfs:subClassOf"],
+                    "direct": false,
+                    "include_self": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "required": ["assayType"],
+          "properties": {
+            "assayType": {
+              "required": ["termId"],
+              "properties": {
+                "termId": {
+                  "title": "Ontology constraint for 'DNA assay'",
+                  "graphRestriction":  {
+                    "ontologies" : ["obo:efo"],
+                    "classes": ["EFO:0001456"],
+                    "relations": ["rdfs:subClassOf"],
+                    "direct": false,
+                    "include_self": false
+                  }
+                }                
+              }
+            }
+          }
+        }
+      },
+      {
+        "title": "If the assayed molecule is 'ribonucleic acid' then, the assay type must be of 'RNA asay' type",
+        "if": {
+          "required": ["assayedBiologicalMacromolecule"],
+          "properties": {
+            "assayedBiologicalMacromolecule": {
+              "required": ["termId"],
+              "properties": {
+                "termId": {
+                  "title": "Ontology constraint for 'ribonucleic acid'",
+                  "graphRestriction ":  {
+                    "ontologies" : ["obo:efo"],
+                    "classes": ["CHEBI:33697"],
+                    "relations": ["rdfs:subClassOf"],
+                    "direct": false,
+                    "include_self": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "required": ["assayType"],
+          "properties": {
+            "assayType": {
+              "required": ["termId"],
+              "properties": {
+                "termId": {
+                  "title": "Ontology constraint for 'RNA assay'",
+                  "graphRestriction":  {
+                    "ontologies" : ["obo:efo"],
+                    "classes": ["EFO:0001457"],
+                    "relations": ["rdfs:subClassOf"],
+                    "direct": false,
+                    "include_self": false
+                  }
+                }                
+              }
+            }
+          }
+        }
+      }
+    ]      
   }

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -78,15 +78,15 @@
           "assayType": {
             "type": "string",
             "title": "Type of the assay",
-            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
+            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
             "anyOf": [
               {
                 "title": "Array-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json"
               },
               {
                 "title": "Sequencer-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json"
+                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json"
               }
             ],
             "examples": [ "Hi-C", "amplicon sequencing", "assay by high throughput sequencer", "immune sequencing", "ChIP-chip by array", "transcription profiling by array", "microRNA profiling by array", "genotyping by array", "comparative genomic hybridization by array" ]
@@ -94,7 +94,7 @@
           "assaySubtype": {
             "type": "string",
             "title": "Subtype of the assay",
-            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_dna.json))",
+            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json))",
             "examples": [ "MC-4C", "UMI-4C", "single nucleus RNA sequencing", "RNA-seq of coding RNA from single cells", "Quant-seq", "DNA-seq", "ATAC-seq", "DNase Hi-C", "scDNase-seq", "in situ HiC", "exome sequencing" ]
           }
         },
@@ -106,11 +106,11 @@
                 "anyOf": [
                   {
                     "title": "DNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_dna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json"
                   },
                   {
                     "title": "RNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_rna.json"
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json"
                   }
                 ]                 
               }
@@ -123,10 +123,10 @@
                 "title": "Assay type and subtype terms are from the array CV list",
                 "properties": {
                   "assayType": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_array.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json" 
                   },
                   "assaySubtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_array.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json" 
                   }
                 }
               },
@@ -134,10 +134,10 @@
                 "title": "Assay type and subtype terms are from the sequencer CV list",
                 "properties": {
                   "assayType": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assayType_by_sequencer.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json" 
                   },
                   "assaySubtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assaySubtype_by_sequencer.json" 
+                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json" 
                   }
                 }
               }

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -108,28 +108,31 @@
         }
       },
 
-      "assayedMoleculeType": {
-        "type": "string",
-        "title": "Type of the assayed molecule of the experiment",
-        "description": "Node containing information about the assayed molecule: the material entity (e.g. DNA) that was used to generate the data. Choose the specific terms if possible (e.g. if the assayed molecule is cDNA, pick 'cDNA' instead of just 'DNA'). Term chosen from a list of controlled vocabulary (CV). If you cannot find your term in the CV list, please create an issue at our [metadata GitHub repository](https://github.com/EbiEga/ega-metadata-schema/issues/new/choose) proposing its addition.",
-        "enum": [ "DNA", "RNA", "metabolite", "protein", "cDNA", "genomic DNA", "mitochondrial DNA", "messenger RNA", "ncRNA", "non polyA RNA", "long non polyA RNA", "nuclear RNA", "polyA RNA", "long polyA RNA", "snRNA", "total RNA" ],
-        "meta:enum": {
-          "DNA": "[CHEBI:16991]",
-          "RNA": "[CHEBI:33697]",
-          "metabolite": "[EFO:0004727]",
-          "protein": "[CHEBI:36080]",
-          "cDNA": "[EFO:0008481]",
-          "genomic DNA": "[EFO:0008479]",
-          "mitochondrial DNA": "[EFO:0008480]",  
-          "messenger RNA": "[CHEBI:33699]",
-          "ncRNA": "[SO:0000655]",
-          "non polyA RNA": "[EFO:0005017]",
-          "long non polyA RNA": "[EFO:0005018]",
-          "nuclear RNA": "[EFO:0030052]",
-          "polyA RNA": "[OBI:0000869]",
-          "long polyA RNA": "[EFO:0005019]",
-          "snRNA": "[SO:0000274]",
-          "total RNA": "[EFO:0004964]" }
+      "assayedBiologicalMacromolecule": {
+        "type": "object",
+        "title": "Assayed biological macromolecule",
+        "description": "Node containing information about the assayed biological macromolecule: the material entity (e.g. 'nuclear RNA') that was assayed to generate the data. We recommend that you choose the most specific term that applies to your case: for example, if the assayed molecule is 'long non polyA RNA', choose the specific term 'long non polyA RNA' [EFO:0005018], instead of the generic term 'ribonucleic acid' [CHEBI:33697].",
+        "meta:propertyCurie": "EFO:0004446",
+        "allOf": [
+          {
+            "title": "Inherited ontologyTerm structure of termId and termLabel",
+            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+          }
+        ],
+        "properties": {        
+          "termId": {
+            "title": "Ontology constraints for this specific termId",
+            "description": "",
+            "graphRestriction ":  {
+              "ontologies" : ["obo:efo"],
+              "classes": ["EFO:0004446"],
+              "relations": ["rdfs:subClassOf"],
+              "direct": false,
+              "include_self": false
+            },
+            "examples": [ "EFO:0005018", "CHEBI:33697", "EFO:0005019" ]
+          }
+        }
       },
 
       "typesOfOutputData": {

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -6,7 +6,7 @@
     "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its experiment metadata object. An experiment is considered a planned and intentionally designed process performed as part of a study. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "required": ["objectId", "assayTechnology", "assayTypeDescriptor", "assayedMoleculeType", "experimentTypeSpecifications"],
+    "required": ["objectId", "assayTechnology", "assayType", "assayedMoleculeType", "experimentTypeSpecifications"],
     "additionalProperties": false,
     "properties": {
       "objectId": {
@@ -67,83 +67,45 @@
         "$ref": "./EGA.common-definitions.json#/definitions/assayTechnologyDescriptor"
       },
 
-      "assayTypeDescriptor": {
+      "assayType": {
         "type": "object",
-        "title": "Type of assay",
+        "title": "Type of used assay",
         "meta:propertyCurie": "OBI:0000070",
-        "description": "Node defining the type of assay applicable to the experiment. Consists in an overall category (based on the purpose and technology of the instrument [EFO:0002773]) and its possible subtype. Both types and subtypes are taken from controlled vocabulary (CV) lists, stored in the controlled_vocabulary_schemas folder. For example, in a single cell RNA-seq assay the assay type would be 'assay by high throughput sequencer' [EFO:0002697] and its subtype 'RNA-seq of coding RNA from single cells' [EFO:0005684].",
-        "additionalProperties": false,
-        "required": ["assayType"],
+        "description": "Node defining the type of assay applicable to the experiment. Notice how, depending on the complexity of the assay type (i.e. how many subtypes it may have), the assay type can be a high level term (e.g. 'single cell sequencing') or very specific (e.g. '454 Sequencing'). We recommend to use the most specific term possible if available: for example, in case your assay was an 'RNA-seq of coding RNA from single cells' [EFO:0005684], we advise to provide the specific term [EFO:0005684], instead of the generic 'assay by high throughput sequencer' [EFO:0002697].",
+        "allOf": [
+          {
+            "title": "Inherited ontologyTerm structure of termId and termLabel",
+            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+          }
+        ],
         "properties": {
-          "assayType": {
-            "type": "string",
-            "title": "Type of the assay",
-            "description": "Overall type of the assay. Term chosen from a controlled vocabulary (CV) list. Search for yours either at (1) our GitHub repository ([array types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json) and [sequencing types](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json)) or (2) in the OLS service ([sequencing types](http://www.ebi.ac.uk/efo/EFO_0003740) and [array types](http://www.ebi.ac.uk/efo/EFO_0002696)).",
+          "termId": {
+            "title": "Ontology constraints for this specific termId",
             "anyOf": [
               {
-                "title": "Array-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json"
+                "title": "Ontology validation of terms below 'assay by sequencer'",
+                "graphRestriction":  {
+                  "ontologies" : ["obo:efo"],
+                  "classes": ["EFO:0003740"],
+                  "relations": ["rdfs:subClassOf"],
+                  "direct": true,
+                  "include_self": false
+                }
               },
               {
-                "title": "Sequencer-assay type controlled vocabulary (CV) list",
-                "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json"
+                "title": "Ontology validation of terms below 'assay by array'",
+                "graphRestriction":  {
+                  "ontologies" : ["obo:efo"],
+                  "classes": ["EFO:0002696"],
+                  "relations": ["rdfs:subClassOf"],
+                  "direct": true,
+                  "include_self": false
+                }
               }
             ],
-            "examples": [ "Hi-C", "amplicon sequencing", "assay by high throughput sequencer", "immune sequencing", "ChIP-chip by array", "transcription profiling by array", "microRNA profiling by array", "genotyping by array", "comparative genomic hybridization by array" ]
-          },
-          "assaySubtype": {
-            "type": "string",
-            "title": "Subtype of the assay",
-            "description": "Subtype of the assay: any ontologized term hierarchically below the assay type. Term chosen from a controlled vocabulary (CV) list. Search for yours at our GitHub repository: [array subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json), [sequencing subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json), [RNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json) and [DNA assay subtypes](https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json))",
-            "examples": [ "MC-4C", "UMI-4C", "single nucleus RNA sequencing", "RNA-seq of coding RNA from single cells", "Quant-seq", "DNA-seq", "ATAC-seq", "DNase Hi-C", "scDNase-seq", "in situ HiC", "exome sequencing" ]
+            "examples": [ "EFO:0002697", "EFO:0030006", "EFO:0002765", "EFO:0005517" ]
           }
-        },
-        "anyOf": [
-          {
-            "title": "Assay subtypes match DNA/RNA assays",
-            "properties": {
-              "assaySubtype": {
-                "anyOf": [
-                  {
-                    "title": "DNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_dna.json"
-                  },
-                  {
-                    "title": "RNA-Assay subtype controlled vocabulary (CV) list",
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_rna.json"
-                  }
-                ]                 
-              }
-            }
-          },
-          {
-            "title": "Assay subtypes match array/sequencer assays",
-            "oneOf": [
-              {
-                "title": "Assay type and subtype terms are from the array CV list",
-                "properties": {
-                  "assayType": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_array.json" 
-                  },
-                  "assaySubtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_array.json" 
-                  }
-                }
-              },
-              {
-                "title": "Assay type and subtype terms are from the sequencer CV list",
-                "properties": {
-                  "assayType": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_type_by_sequencer.json" 
-                  },
-                  "assaySubtype": {
-                    "$ref": "./controlled_vocabulary_schemas/EGA.cv.assay_subtype_by_sequencer.json" 
-                  }
-                }
-              }
-            ]
-          }
-        ]
+        }
       },
 
       "assayedMoleculeType": {

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,7 +6,6 @@ is one schema file (_e.g._ ``EGA.experiment.json``) for every metadata object (_
 reference.
 * An **object-set** (``EGA.object-set.json``) is, simply put, an array of EGA metadata objects. In other words, a compilation of individual metadata objects (e.g. 20 ``samples``, 2 ``assays`` and 1 ``experiment`` - any combination is valid) that are validated individually. The purpose of an object-set is to avoid the need of one file per each of the metadata objects (e.g. 100 sample JSON documents
  if we were to validate 100 sample objects), being able to group them all in a single file.
-* Some **controlled vocabularies** also reside within the ``controlled_vocabulary_schemas/`` directory in a JSON schema format. These schemas exist so that the common definitions file is not large enough for problems viewing and editing it arise.
 
 The current schemas are written in JavaScript Object Notation (**JSON**), providing both human- and machine-readable documentation. For further details regarding JSON-schemas visit [JSON-schema](https://json-schema.org/) and [Getting started](https://json-schema.org/learn/getting-started-step-by-step) (for an overview), or
 [Understanding JSON schema](https://json-schema.org/understanding-json-schema/) (for a detailed explanation).


### PR DESCRIPTION
## Ticket reference
EEH-2488

## Overall changes
- Removed CV constraint on Assay instrument platforms
- Amended typos in the CV list names
- Transformed ``assayType`` into an ``ontologyTerm``-property
- Updated documentation without ``controlled_vocabulary_schemas``
- Amended JSON document examples after updating ``assayType``
- Transformed ``assayedMoleculeType`` into ``assayedBiologicalMacromolecule`` as an ``ontologyTerm``-property
- Simplified syntaxis of ``arraySampleLabels``
- Modified assay's ``assayType`` to ``assayInstrument``
- Added constraint for matching ``AssayType`` and assayed molecules

## Future TO-DOs
- [ ] Given the current issues with BioV (https://github.com/elixir-europe/biovalidator/issues/57), I am unable to check if the JSON documents are valid or not. Instead, once merged with main, I will check fetching them through BioV, works around this issue.
