### PR TITLE
EEH-2506 - Modified "phenotypes" and "diseases" arrays

### DIFF
--- a/examples/json_validation_tests/individual_valid-1.json
+++ b/examples/json_validation_tests/individual_valid-1.json
@@ -30,18 +30,38 @@
             "biologicalSex": "male",
             "diseases": [
                 {
-                    "termId": "EFO:0003101",
-                    "termLabel": "testicular seminoma"
+                    "excluded": true,
+                    "disease": {
+                        "termId": "EFO:0003101",
+                        "termLabel": "testicular seminoma"
+                    }
                 },
                 {
-                    "termId": "EFO:1000254",
-                    "termLabel": "fibroadenoma"
+                    "excluded": true,
+                    "disease": {
+                        "termId": "MONDO:0019808",
+                        "termLabel": "aortic valve atresia"
+                    }
+                },             
+                {
+                    "disease": {
+                        "termId": "EFO:1000254",
+                        "termLabel": "fibroadenoma"
+                    }
+                },
+                {
+                    "disease": {
+                        "termId": "Orphanet:610",
+                        "termLabel": "Bethlem myopathy"
+                    }
                 }
             ],
-            "phenotypes": [
+            "phenotypicAbnormalities": [
                 {
-                    "termId": "HP:0033403",
-                    "termLabel": "Testicular ischemia"
+                    "phenotypicAbnormality": {
+                        "termId": "HP:0033403",
+                        "termLabel": "Testicular ischemia"
+                    }
                 }
             ],
             "subjectId": "donor-NM305004"

--- a/examples/json_validation_tests/object-set_Covid19.json
+++ b/examples/json_validation_tests/object-set_Covid19.json
@@ -16,25 +16,35 @@
                     "biologicalSex": "male",
                     "diseases": [
                         {
-                            "termId": "MONDO:0100096",
-                            "termLabel": "COVID-19"
+                            "disease": {
+                                "termId": "MONDO:0100096",
+                                "termLabel": "COVID-19"
+                            }
                         },
                         {
-                            "termId": "EFO:0000400",
-                            "termLabel": "Diabetes Mellitus"
+                            "disease": {
+                                "termId": "EFO:0000400",
+                                "termLabel": "Diabetes Mellitus"
+                            }
                         },
                         {
-                            "termId": "EFO:0000318",
-                            "termLabel": "Cardiomyopathy"
+                            "disease": {
+                                "termId": "EFO:0000318",
+                                "termLabel": "Cardiomyopathy"
+                            }
                         },
                         {
-                            "termId": "EFO:0009909",
-                            "termLabel": "Chronic Kidney Disease"
+                            "disease": {
+                                "termId": "EFO:0009909",
+                                "termLabel": "Chronic Kidney Disease"
+                            }
                         },
                         {
-                            "termId": "EFO:0001073",
-                            "termLabel": "Obesity"
-                        }
+                            "disease": {
+                                "termId": "EFO:0001073",
+                                "termLabel": "Obesity"
+                            }
+                        }                        
                     ]
                 },
                 "organismDescriptor": {

--- a/examples/json_validation_tests/object-set_RareDisease.json
+++ b/examples/json_validation_tests/object-set_RareDisease.json
@@ -14,29 +14,39 @@
                 "minimalPublicAttributes": {
                     "subjectId": "Affected_proband_14y",
                     "biologicalSex": "male",
-                    "phenotypes": [
+                    "phenotypicAbnormalities": [
                         {
-                            "termId": "HP:0001558",
-                            "termLabel": "Decreased fetal movement"
+                            "phenotypicAbnormality": {
+                                "termId": "HP:0001558",
+                                "termLabel": "Decreased fetal movement"
+                            }
                         },
                         {
-                            "termId": "HP:0031910",
-                            "termLabel": "Abnormal cranial nerve physiology"
+                            "phenotypicAbnormality": {
+                                "termId": "HP:0031910",
+                                "termLabel": "Abnormal cranial nerve physiology"
+                            }
                         },
                         {
-                            "termId": "HP:0012587",
-                            "termLabel": "Macroscopic hematuria"
+                            "phenotypicAbnormality": {
+                                "termId": "HP:0012587",
+                                "termLabel": "Macroscopic hematuria"
+                            }
                         },
                         {
-                            "termId": "HP:0001270",
-                            "termLabel": "Motor delay"
-                        }
+                            "phenotypicAbnormality": {
+                                "termId": "HP:0001270",
+                                "termLabel": "Motor delay"
+                            }
+                        }                        
                     ],
                     "diseases": [
                         {
-                            "termId": "MONDO:0008029",
-                            "termLabel": "Bethlem myopathy"
-                        }
+                            "disease": {
+                                "termId": "MONDO:0008029",
+                                "termLabel": "Bethlem myopathy"
+                            }
+                        }                        
                     ]
                 },
                 "organismDescriptor": {
@@ -82,10 +92,12 @@
                 "minimalPublicAttributes": {
                     "subjectId": "Unaffected mother",
                     "biologicalSex": "female",
-                    "phenotypes": [
+                    "phenotypicAbnormalities": [
                         {
-                            "termId": "NCIT:C94232",
-                            "termLabel": "Unaffected"
+                            "phenotypicAbnormality": {
+                                "termId": "NCIT:C94232",
+                                "termLabel": "Unaffected"
+                            }
                         }
                     ]
                 },

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -3799,10 +3799,30 @@
             "title": "Ontology constraints for this specific termId",
             "anyOf": [
               {
-                "title": "Ontology validation of diseases",
+                "title": "Ontology validation of 'disease' - EFO",
                 "graphRestriction":  {
                   "ontologies" : ["obo:efo"],
                   "classes": ["EFO:0000408"],
+                  "relations": ["rdfs:subClassOf"],
+                  "direct": false,
+                  "include_self": false
+                }
+              },
+              {
+                "title": "Ontology validation of 'disease' - ORDO",
+                "graphRestriction":  {
+                  "ontologies" : ["obo:ordo"],
+                  "classes": ["Orphanet:377788"],
+                  "relations": ["rdfs:subClassOf"],
+                  "direct": false,
+                  "include_self": false
+                }
+              },
+              {
+                "title": "Ontology validation of 'human disease or disorder' - MONDO",
+                "graphRestriction":  {
+                  "ontologies" : ["obo:mondo"],
+                  "classes": ["MONDO:0700096"],
                   "relations": ["rdfs:subClassOf"],
                   "direct": false,
                   "include_self": false

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -52,14 +52,29 @@
           "biologicalSex": {
             "$ref": "./EGA.common-definitions.json#/definitions/biologicalSex"
           },
-          "phenotypes": {
+          "phenotypicAbnormalities": {
             "type": "array",
             "title": "Array of phenotypic abnormalities",
             "minItems": 1,
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/phenotypicAbnormality"
+              "type": "object",
+              "title": "Phenotypic abnormality item",
+              "description": "One individual Phenotypic abnormality of the array. Keep in mind that in order to correctly interprete the phenotype it is **imperative** to check the 'excluded' property: each item of the array can be either specifying that the phenotipic abnormality was present or the opposite (i.e. logical negation).",
+              "additionalProperties": false,
+              "required": [ "phenotypicAbnormality" ],
+              "properties": {
+                "excluded": {
+                  "type": "boolean",
+                  "title": "Excluded",
+                  "description": "Property that specifies whether the phenotype was observed or not. Similar to phenopacket's 'excluded' property, by default it is 'false', which means that the phenotype was observed (i.e. not excluded). This flag is only required to indicate that the phenotype was looked for, but found to be absent. The terms 'not excluded' (i.e. false) and 'excluded' (i.e. true) correlate with the common notation of 'case' versus 'control', respectively.",
+                  "default": false
+                },
+                "phenotypicAbnormality": {
+                  "$ref": "./EGA.common-definitions.json#/definitions/phenotypicAbnormality"
+                }
+              }
             }
           },
           "diseases": {
@@ -69,7 +84,22 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/disease"
+              "type": "object",
+              "title": "Disease item",
+              "description": "One individual disease of the array. Keep in mind that in order to correctly interprete the disease it is **imperative** to check the 'excluded' property: each item of the array can be either specifying that the disease was present or the opposite (i.e. logical negation).",
+              "additionalProperties": false,
+              "required": [ "disease" ],
+              "properties": {
+                "excluded": {
+                  "type": "boolean",
+                  "title": "Excluded",
+                  "description": "Property that specifies whether the disease was observed or not. Similar to phenopacket's 'excluded' property, by default it is 'false', which means that the disease was observed (i.e. not excluded). This flag is only required to indicate that the disease was looked for, but found to be absent. The terms 'not excluded' (i.e. false) and 'excluded' (i.e. true) correlate with the common notation of 'case' versus 'control', respectively.",
+                  "default": false
+                },
+                "disease": {
+                  "$ref": "./EGA.common-definitions.json#/definitions/disease"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
## Ticket reference
EEH-2506

## Overall changes
- Added ``excluded`` property so that logic negation of diseases and phenotypes can be made
- Added more hierarchies to the ontology validation of diseases (main point of this thread: https://github.com/EbiEga/ega-metadata-schema/pull/63#discussion_r1085501712)
- Amended examples

## Future TO-DOs
- [x] Since I cannot deploy Biovalidator with local schemas (https://github.com/elixir-europe/biovalidator/issues/57), I couldn't test that the JSON examples are valid against the schemas. Once merged I'll test it and amend it otherwise. 
