### PR TITLE
EEH-2525 - Amend ``git rm``

### DIFF
--- a/.github/workflows/markdown_creation.yml
+++ b/.github/workflows/markdown_creation.yml
@@ -63,6 +63,9 @@ jobs:
           # We add new additions
           git add $markdown_dir/*
           # And add to stage the deleted files as well
-          git rm $(git ls-files --deleted "$markdown_dir")
+          deleted_files=$(git ls-files --deleted "$markdown_dir")
+          if [ -n "$deleted_files" ]; then
+            git rm $deleted_files
+          fi
           git commit -m "JSON Schemas to Markdown - $today"
           git push origin main


### PR DESCRIPTION
## Ticket reference

## Overall changes
- Amended the ``git rm`` command in the markdown creation, which was failing when there were no files to remove.

## Future TO-DOs and checks
- [ ] Check that the object's versions (i.e. ``meta:version``) are updated before creating the PR (see [GitHub Action](../.github/workflows/update_version_manifest.yml)). 
- [ ] Check that the version manifest is up to date right before merging (see [documentation](../docs/releases/README.md#updating-the-version-manifest)). 
