### PR TITLE
EE-2699 - Added script and workflow to test backwards compatibility

### DIFF
--- a/.github/scripts/check_project_version_change.py
+++ b/.github/scripts/check_project_version_change.py
@@ -1,0 +1,81 @@
+import os
+import argparse
+
+from utils.git_manipulation import get_current_branch, \
+    load_main_json
+from utils.json_manipulation import get_highest_version_index
+from utils.string_manipulation import is_semantic_version, \
+    compare_semantic_versions
+
+# Script used to check whether the change in version of the project is major or 
+#   not.
+# For further details, please check:
+#   https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases
+
+# --------- #
+# Handling arguments
+# --------- #
+parser = argparse.ArgumentParser(
+    description="Checks whether the change in version of the project is major (returning 'Major') or not (returning either 'Minor' or 'Patch'). The version change is defined as the difference in semantic versionings between the 'current branch' (e.g. '1.0.0') and the highest version within the version_manifest file (e.g. '0.0.0'). The script can be used to check whether backwards compatibility needs to be test: only if a non-major change occurs in the project. Check further details at https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases."
+)
+parser.add_argument(
+    "--version_manifest_dir",
+    type=str,
+    default="./docs/releases",
+    help='The path to the version manifest directory. Default: "./docs/releases"',
+)
+parser.add_argument(
+    "--new_release_version",
+    type=str,
+    default=None,
+    help='Semantic version of the new project release version to use instead of the current branch name. Do NOT use unless you know exactly what you are doing: to comply with the release workflow, the version should normally be taken from the branch name. Default: None',
+)
+args = parser.parse_args()
+
+# Check the integrity of the given arguments
+if not isinstance(args.version_manifest_dir, str):
+    raise ValueError(f"Version manifest directory (--version_manifest_dir) must be a string.")
+if args.new_release_version:
+    if not is_semantic_version(args.new_release_version):
+        raise ValueError(f"The given new release version ('{args.new_release_version}') does not follow semantic versioning.")
+
+# --------- #
+# Main function for the check
+# --------- #
+def main(args: argparse.Namespace) -> bool:
+    # Hardcoded values
+    schema_repo_filepath = "."
+    releases_array_keyword = "releases"
+    version_keyword = "version"
+    version_manifest_file = f"{args.version_manifest_dir}/version_manifest.json"
+
+    # We get the new version of the project
+    if not args.new_release_version:
+        new_version = get_current_branch(directory_path = schema_repo_filepath)
+        if not is_semantic_version(new_version):
+            raise ValueError(f"The current branch name ('{new_version}') does not follow semantic versioning.")
+    else:
+        new_version = args.new_release_version
+
+    main_version_manifest_json = load_main_json(file_path = version_manifest_file)
+
+    # We get the highest version of all the releases within the manifest file
+    highest_version_index = get_highest_version_index(version_manifest_json=main_version_manifest_json)
+    highest_version = main_version_manifest_json[releases_array_keyword][highest_version_index][version_keyword]
+
+    # Time to compare the new and old versions, to assert that the new is higher
+    new_is_higher, change_type = compare_semantic_versions(
+        old_version=highest_version,
+        new_version=new_version
+    )
+    if not new_is_higher:
+        raise ValueError(
+            f"The version represented by the branch name ({new_version}) was lower or equal than one in the existing "
+            f"version manifest ({highest_version}). In order to comply with semantic versioning, new ones should always be higher."
+        )
+    
+    return change_type
+
+if __name__ == "__main__":
+    version_check_type = main(args)
+    print(version_check_type)

--- a/.github/scripts/check_project_version_change.py
+++ b/.github/scripts/check_project_version_change.py
@@ -52,6 +52,9 @@ def main(args: argparse.Namespace) -> bool:
     # We get the new version of the project
     if not args.new_release_version:
         new_version = get_current_branch(directory_path = schema_repo_filepath)
+        if current_branch_name.startswith("v"):
+            # We get rid of the "v" string that represents the "version"
+            current_branch_name = current_branch_name[1:]
         if not is_semantic_version(new_version):
             raise ValueError(f"The current branch name ('{new_version}') does not follow semantic versioning.")
     else:

--- a/.github/scripts/check_project_version_change.py
+++ b/.github/scripts/check_project_version_change.py
@@ -16,7 +16,7 @@ from utils.string_manipulation import is_semantic_version, \
 # Handling arguments
 # --------- #
 parser = argparse.ArgumentParser(
-    description="Checks whether the change in version of the project is major (returning 'Major') or not (returning either 'Minor' or 'Patch'). The version change is defined as the difference in semantic versionings between the 'current branch' (e.g. '1.0.0') and the highest version within the version_manifest file (e.g. '0.0.0'). The script can be used to check whether backwards compatibility needs to be test: only if a non-major change occurs in the project. Check further details at https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases."
+    description="Checks whether the change in version of the project is major (returning 'Major') or not (returning either 'Minor' or 'Patch'). The version change is defined as the difference in semantic versionings between the 'current branch' (e.g. '1.0.0') and the highest version within the version_manifest file (e.g. '0.0.0'). The script can be used to check whether backwards compatibility needs to be tested: only if a non-major change occurs in the project. Check further details at https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases."
 )
 parser.add_argument(
     "--version_manifest_dir",

--- a/.github/scripts/check_project_version_change.py
+++ b/.github/scripts/check_project_version_change.py
@@ -86,9 +86,9 @@ def main(args: argparse.Namespace) -> bool:
     highest_version_index = get_highest_version_index(version_manifest_json=main_version_manifest_json)
     highest_version = main_version_manifest_json[releases_array_keyword][highest_version_index][version_keyword]
     print_verbose(
-        f"- Comparison of versions:"
-        f"\tThe new version is '{new_version}'"
-        f"\tThe highest existing version in the version manifest is '{highest_version}'",
+        f"- Comparison of versions:\n"
+        f"\tThe new version is '{new_version}'\n"
+        f"\tThe highest existing version in the version manifest is '{highest_version}'\n",
         args.verbose
     )
 
@@ -104,7 +104,7 @@ def main(args: argparse.Namespace) -> bool:
         )
     
     print_verbose(
-        f"- The change type is '{change_type}'",
+        f"- The change type is '{change_type}'\n",
         args.verbose
     )
 

--- a/.github/scripts/fetch_github_documents.py
+++ b/.github/scripts/fetch_github_documents.py
@@ -1,0 +1,60 @@
+import os
+import argparse
+
+from utils.git_manipulation import fetch_and_copy_files
+
+# Script used to copy all files within a GitHub directory to a local directory.
+#   Example: to download JSON Examples from "main" during a GitHub workflow.
+
+# --- #
+# Initial arguments
+# --- #
+parser = argparse.ArgumentParser(
+    description="Copies all files from within a directory of a GitHub repository into a local directory (e.g. all JSON files from within './examples/json_validation_tests').",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+parser.add_argument(
+    "--input_directory",
+    type=str,
+    required=True,
+    help='The path to a directory within the GitHub repository whose files will be copied. Example: "./examples/json_validation_tests"',
+)
+parser.add_argument(
+    "--destination_directory",
+    type=str,
+    required=True,
+    help='The path to the local directory to which all files will be copied. Example: "./"',
+)
+parser.add_argument(
+    "--branch",
+    type=str,
+    required=False,
+    default="main",
+    help='The branch of the GitHub repository to use. Default: "main"',
+)
+args = parser.parse_args()
+
+# # Check the integrity of the given arguments
+if not isinstance(args.input_directory, str):
+    raise ValueError("input_directory must be a string.")
+if not isinstance(args.destination_directory, str):
+    raise ValueError("destination_directory must be a string.")
+if not isinstance(args.branch, str):
+    raise ValueError("branch must be a string.")
+
+# --- #
+# Copying the files
+# --- #
+def create_directory(directory_name):
+    if not os.path.exists(directory_name):
+        os.mkdir(directory_name)
+        print(f"Directory '{directory_name}' created successfully.")
+    else:
+        print(f"Directory '{directory_name}' already exists.")
+
+create_directory(args.destination_directory)
+fetch_and_copy_files(
+    destination_directory_name=args.destination_directory,
+    directory_to_copy=args.input_directory,
+    verbose=True
+)

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -7,3 +7,4 @@ jsonpath_ng
 jsonref
 jsonschema==3.2.0
 GitPython==3.1.30
+semver==3.0.1

--- a/.github/scripts/update_version_manifest.py
+++ b/.github/scripts/update_version_manifest.py
@@ -10,7 +10,7 @@ from utils.json_manipulation import JSONManipulationFormatter, \
     get_highest_version_index
 from utils.string_manipulation import is_semantic_version, \
     get_keys_for_diff_values, \
-    is_higher_version
+    compare_semantic_versions
 from utils.json_validation import validate_json
 
 # Script used to update the version manifest (./docs/releases) with the versions of the JSON schemas. For further details, please check:
@@ -164,9 +164,9 @@ if highest_version_index is not None:
     # We iterate over the objects with diff. versions, creating "changedJsonSchemas"
     changed_version_dict = {}
     for object_name in diff_keys_list:
-        new_is_higher = is_higher_version(
-            o_lower_version=highest_allJsonSchemas[object_name], 
-            o_higher_version=new_allJsonSchemas[object_name]
+        new_is_higher, version_change = compare_semantic_versions(
+            old_version=highest_allJsonSchemas[object_name],
+            new_version=new_allJsonSchemas[object_name]
         )
         if not new_is_higher:
             raise ValueError(

--- a/.github/scripts/utils/git_manipulation.py
+++ b/.github/scripts/utils/git_manipulation.py
@@ -30,18 +30,28 @@ def get_current_branch(directory_path: str) -> Union[str, None]:
         return None
     
 
-def load_main_json(file_path: str, base_url: str = "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main") -> dict:
+def load_main_json(file_path: str, base_url: str = None) -> dict:
     """
     Given a file path, returns the loaded JSON file of its version of the "main" branch of the ega-metadata-schema repository
     """
+    if base_url is None:
+        base_url = os.getenv('BASE_URL')
+        if base_url is None:
+            raise EnvironmentError(
+                "The environment variable 'BASE_URL' is not set. "
+                "Please set this variable to the base URL for your repository, e.g., "
+                "'https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main'"
+            )
+
     file_extension = os.path.splitext(file_path)[1].lower()
     if not file_extension == ".json":
         raise ValueError(f"Given file path is not of a JSON file: {file_path}")
+
     url = f"{base_url}/{file_path}"
     response = requests.get(url)
     if not response.status_code == requests.codes.ok:
         error_message = (
-            f"The POST response was not successful: the status code was '{response.status_code}' when trying to"
+            f"The GET request was not successful: the status code was '{response.status_code}' when trying to"
             f" fetch file '{os.path.basename(file_path)}' from the repository at the given URL: {url}"
         )
         raise requests.HTTPError(error_message)

--- a/.github/scripts/utils/git_manipulation.py
+++ b/.github/scripts/utils/git_manipulation.py
@@ -60,13 +60,22 @@ def load_main_json(file_path: str, base_url: str = None) -> dict:
 def fetch_and_copy_files(
     directory_to_copy: str,
     destination_directory_name: str = "./",
-    repository_url: str = "https://api.github.com/repos/EbiEga/ega-metadata-schema",
+    repository_url: str = None,
     verbose: bool = False,
     branch: str = "main"
     ):
     """
     Given a repository URL and its directory to copy, it copies the contents to another given destination directory.
     """
+    if repository_url is None:
+        repository_url = os.getenv('REPOSITORY_URL')
+        if repository_url is None:
+            raise EnvironmentError(
+                "The environment variable 'REPOSITORY_URL' is not set. "
+                "Please set this variable to the base URL for your repository, e.g., "
+                "'https://api.github.com/repos/EbiEga/ega-metadata-schema'"
+            )
+    
     # Fetch the contents of the directory from the GitHub API
     api_url = f"{repository_url}/contents/{directory_to_copy}?ref={branch}"
     response = requests.get(api_url)

--- a/.github/scripts/utils/git_manipulation.py
+++ b/.github/scripts/utils/git_manipulation.py
@@ -39,8 +39,12 @@ def load_main_json(file_path: str, base_url: str = "https://raw.githubuserconten
         raise ValueError(f"Given file path is not of a JSON file: {file_path}")
     url = f"{base_url}/{file_path}"
     response = requests.get(url)
-    if response.status_code != 200:
-        raise FileNotFoundError(f"Given file '{os.path.basename(file_path)}' was not found in the repository's main branch at the given URL: {url}")
+    if not response.status_code == requests.codes.ok:
+        error_message = (
+            f"The POST response was not successful: the status code was '{response.status_code}' when trying to"
+            f" fetch file '{os.path.basename(file_path)}' from the repository at the given URL: {url}"
+        )
+        raise requests.HTTPError(error_message)
     return response.json()
 
 def fetch_and_copy_files(

--- a/.github/scripts/utils/git_manipulation.py
+++ b/.github/scripts/utils/git_manipulation.py
@@ -9,8 +9,10 @@
 # System imports
 # - #
 import git
+import os
+import requests
 from typing import Union
-
+import urllib.request
 
 # -#
 # Helper functions
@@ -26,3 +28,50 @@ def get_current_branch(directory_path: str) -> Union[str, None]:
     except git.InvalidGitRepositoryError:
         print(f"The given directory ('{directory_path}') is neither a valid Git repository nor has a parent directory that is.")
         return None
+    
+
+def load_main_json(file_path: str, base_url: str = "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main") -> dict:
+    """
+    Given a file path, returns the loaded JSON file of its version of the "main" branch of the ega-metadata-schema repository
+    """
+    file_extension = os.path.splitext(file_path)[1].lower()
+    if not file_extension == ".json":
+        raise ValueError(f"Given file path is not of a JSON file: {file_path}")
+    url = f"{base_url}/{file_path}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise FileNotFoundError(f"Given file '{os.path.basename(file_path)}' was not found in the repository's main branch at the given URL: {url}")
+    return response.json()
+
+def fetch_and_copy_files(
+    directory_to_copy: str,
+    destination_directory_name: str = "./",
+    repository_url: str = "https://api.github.com/repos/EbiEga/ega-metadata-schema",
+    verbose: bool = False,
+    branch: str = "main"
+    ):
+    """
+    Given a repository URL and its directory to copy, it copies the contents to another given destination directory.
+    """
+    # Fetch the contents of the directory from the GitHub API
+    api_url = f"{repository_url}/contents/{directory_to_copy}?ref={branch}"
+    response = requests.get(api_url)
+    if response.status_code == 200:
+        files = response.json()
+        for file in files:
+            filename = file["name"]
+            download_url = file["download_url"]
+            destination_file = os.path.join(destination_directory_name, filename)
+            
+            try:
+                with urllib.request.urlopen(download_url) as response:
+                    with open(destination_file, 'wb') as output_file:
+                        output_file.write(response.read())
+                if verbose:
+                    print(f"File '{filename}' copied successfully.")
+            except urllib.error.HTTPError as e:
+                raise RuntimeError(f"Error copying file '{filename}': {e}")
+            except Exception as e:
+                raise RuntimeError(f"An error occurred while copying file '{filename}': {e}")
+    else:
+        raise RuntimeError(f"Failed to fetch directory contents from '{repository_url}': {response.status_code} - {response.text}")

--- a/.github/scripts/utils/json_manipulation.py
+++ b/.github/scripts/utils/json_manipulation.py
@@ -336,7 +336,6 @@ def get_highest_version_index(version_manifest_json: dict) -> Union[int, None]:
     if len(releases) == 0:
         return None
     elif len(releases) == 1:
-        print("only one")
         return 0
     
     highest_version_index = 0

--- a/.github/scripts/utils/plantuml_format.py
+++ b/.github/scripts/utils/plantuml_format.py
@@ -16,7 +16,8 @@ from json_manipulation import create_parent_json_paths, \
 
 from string_manipulation import remove_char_from_list, \
     add_char_to_list, \
-    create_highlights_liner
+    create_highlights_liner, \
+    validate_json_file_path
 
 # -#
 # Hardcoded values
@@ -68,11 +69,7 @@ class PlantUMLFormatter:
             self.original_json = json_data
 
         elif json_filepath:
-            file_extension = os.path.splitext(json_filepath)[1].lower()
-            if not os.path.isfile(json_filepath) or not file_extension == ".json":
-                raise ValueError(
-                    f"The given JSON filepath ('{json_filepath}') was not a file or is not a JSON file (*.json)."
-                )
+            validate_json_file_path(json_filepath)
             self.json_filepath = json_filepath
             with open(json_filepath, "r", encoding="utf-8") as json_file:
                 self.original_json = json.load(json_file)

--- a/.github/scripts/utils/string_manipulation.py
+++ b/.github/scripts/utils/string_manipulation.py
@@ -8,7 +8,6 @@
 # - #
 # System imports
 # - #
-import re
 import os
 from typing import Union
 import semver
@@ -108,19 +107,19 @@ def add_char_to_str(
 
     return updated_string
 
-
 def is_semantic_version(version_string: str) -> bool:
     """
     Checks whether a given string matches semantic versioning pattern (e.g. "1.1.1" is correct; "hello-world" is not).
-    The pattern allows for the three main elements: major version; minor version; and patch version; as well
-        as optional additions like: Pre-release version and Build metadata.
+    The pattern is defined by semver module (https://github.com/python-semver/python-semver) and allows for the three
+    main elements (major, minor, and patch) as well as optional additions like Pre-release and Build metadata.
     """
-    semver_regex = r'^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
-    match = re.match(semver_regex, version_string)
-    there_was_match = match is not None
-    return there_was_match
-
-
+    try:
+        # Raises a ValueError if not following semantic versioning
+        semver.parse_version_info(version_string)
+        return True
+    except ValueError:
+        return False
+    
 def get_keys_for_diff_values(dict1, dict2):
     """
     Returns a list containing the keys whose values differed in the two given dictionaries

--- a/.github/scripts/utils/string_manipulation.py
+++ b/.github/scripts/utils/string_manipulation.py
@@ -11,6 +11,7 @@
 import re
 import os
 from typing import Union
+import semver
 
 # -#
 # Helper functions
@@ -210,21 +211,20 @@ def compare_semantic_versions(old_version: str, new_version: str) -> Union[bool,
     if not is_semantic_version(new_version):
         raise ValueError(f"The given new version ('{new_version}') does not follow semantic versioning.")
     
-    old_major, old_minor, old_patch = map(int, old_version.split('.')[0:3])
-    new_major, new_minor, new_patch = map(int, new_version.split('.')[0:3])
-    
-    is_higher = False
+    # Semver.compare output:
+    #   0 if the versions are equal; a negative integer if the first version is smaller; a positive integer if the first version is bigger.
+    is_higher = semver.compare(new_version, old_version) > 0
     version_change = "Invalid"
 
-    if new_major > old_major:
-        is_higher = True
-        version_change = "Major"
-    elif new_major == old_major:
-        if new_minor > old_minor:
-            is_higher = True
+    if is_higher:
+        old_ver_info = semver.parse_version_info(old_version)
+        new_ver_info = semver.parse_version_info(new_version)
+
+        if new_ver_info.major > old_ver_info.major:
+            version_change = "Major"
+        elif new_ver_info.minor > old_ver_info.minor:
             version_change = "Minor"
-        elif new_minor == old_minor and new_patch > old_patch:
-            is_higher = True
+        elif new_ver_info.patch > old_ver_info.patch:
             version_change = "Patch"
 
     return is_higher, version_change

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -79,10 +79,9 @@ jobs:
         if: ${{ env.version_needs_to_be_checked == 'True' }}
         run: |
           cd biovalidator
-          npm install semver@latest
           npm install
           # We shouldn't need to audit the issues, but for now it is what it is
-          npm audit fix
+          # npm audit fix
 
       - name: Start Biovalidator server (old schemas)
         if: ${{ env.version_needs_to_be_checked == 'True' }}

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -79,6 +79,7 @@ jobs:
         if: ${{ env.version_needs_to_be_checked == 'True' }}
         run: |
           cd biovalidator
+          npm install semver@latest
           npm install
           # We shouldn't need to audit the issues, but for now it is what it is
           npm audit fix

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -1,0 +1,121 @@
+---
+# This workflow checks that the semantic versioning (e.g. 1.1.0) of the GitHub
+#   project is correct, and if it's "minor" or "patch", checks backwards 
+#   compatibility.
+# The logic of this workflow is:
+#   - Details: EE-2699
+#   - Why: it helps avoiding human errors of versions in the schemas not being 
+#       changed when or how they should.
+#   - Would block the PR if failed? Yes, as long as the PR is for a release.
+#   - How: by executing the script check_project_version_change.py, and then,
+#       based on its output, deploying Biovalidator with the old and new schemas
+#       and old and new JSON examples.
+#
+# For more information, check:
+#   https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases
+
+name: |
+  [REQUIRED] Check project version change
+
+on:
+  pull_request:
+    branches: [main]
+    # We only want for it to be triggered when JSON Schemas change in the PR
+    paths:
+      - 'schemas/**.json'
+
+jobs:
+  check-modifications:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # This bit is needed to checkout in the branch that triggered the action
+          #   (e.g. v2.0.1)
+          ref: ${{ github.head_ref }}
+      
+      - uses: actions/setup-python@v4
+        with:
+          # We'll use the latest version of python from major 3 release
+          # This bit is needed for running the following python script
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          requirements_f="./.github/scripts/requirements.txt"
+          if [ -f "$requirements_f" ]; then pip install -r "$requirements_f"; fi
+
+      - name: Run version modification check
+        id: run-version-modification-check
+        run: |
+          script_path="./.github/scripts/check_project_version_change.py"
+          version_change=$(python3 "$script_path")
+        
+        # The output of this previous script will determine if changes are not "major" (i.e. minor or patch), and therefore retrocompatibility
+        #   has to be tested through JSON Schema validation (combination of old and new schemas with old and new examples).
+        #   Thus, only if the variable "version_needs_to_be_checked" from the script is True, the following steps will occur.
+
+        - name: Check if version change is Major
+        id: check-version
+          # This step is just to set the logic for triggering the following steps
+        run: |
+          if [[ "${{ steps.run-version-modification-check.outputs.version_change }}" != "Major" ]]; then
+            echo "::set-output name=version_needs_to_be_checked::True"
+          else
+            echo "::set-output name=version_needs_to_be_checked::False"
+          fi
+
+      - name: Clone Biovalidator
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+          # See https://github.com/elixir-europe/biovalidator#installation
+        run: git clone https://github.com/elixir-europe/biovalidator.git
+
+      - name: Install Biovalidator
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        run: |
+          cd biovalidator
+          npm install
+          # We shouldn't need to audit the issues, but for now it is what it is
+          npm audit fix
+
+      - name: Start Biovalidator server (old schemas)
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+          # We want to specify the OLD JSON schemas, so we DO NOT specify the schemas
+          #   at deployment level, and instead let Biovalidator fetch them from "main"
+        run: |
+          node biovalidator/src/biovalidator &
+          # We stop for a few seconds to give the server some time
+          sleep 3
+
+      - name: Validate JSON examples (old schemas, new examples)
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+          # Validate NEW JSON documents against the OLD (from "main") schemas
+        run: |
+          json_ex_dir="./examples/json_validation_tests"
+          # The following URL points to the locally deployed server of
+          #   Biovalidator
+          url="http://localhost:3020/validate"
+          python3 ./.github/scripts/request_validation.py "$json_ex_dir" "$url"
+
+      - name: Start Biovalidator server (New schemas)
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+          # We want to specify the NEW JSON schemas, so we DO specify the schemas
+          #   at deployment level
+        run: |
+          schemas_dir="./schemas"          
+          node biovalidator/src/biovalidator -r "$schemas_dir/*.json" &
+          sleep 3
+
+      - name: Validate JSON examples (New schemas, old examples)
+        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+          # Validate OLD JSON documents against the NEW (from branch) schemas
+        run: |
+          # We fetch all old JSON examples from "main"
+          old_json_ex_dir="./examples/old_json_validation_tests"
+          json_ex_dir="./examples/json_validation_tests"
+          python3 ./.github/scripts/fetch_github_documents.py --input_directory "$json_ex_dir" --destination_directory "$old_json_ex_dir"
+          url="http://localhost:3020/validate"
+          python3 ./.github/scripts/request_validation.py "$old_json_ex_dir" "$url"

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -49,8 +49,14 @@ jobs:
       - name: Run version modification check
         id: run-version-modification-check
         run: |
+          #! Added for debugging purposes:
+          echo "Working directory: $(pwd)"
+          echo "Listing files in script directory:"
+          ls -la ./.github/scripts/
+          #! 
+          
           script_path="./.github/scripts/check_project_version_change.py"
-          python3 "$script_path" --git_var_name "VERSION_CHANGE"
+          python3 "$script_path" --git_var_name "VERSION_CHANGE" --verbose
           echo "- The version change is: $VERSION_CHANGE"
         
         # The output of this previous script will determine if changes are not "major" (i.e. minor or patch), and therefore retrocompatibility
@@ -99,12 +105,39 @@ jobs:
           url="http://localhost:3020/validate"
           python3 ./.github/scripts/request_validation.py "$json_ex_dir" "$url"
 
+      - name: Kill previous Biovalidator server
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
+          # We kill the existing Biovalidator server if it exists
+        run: |
+          # File path
+          file="./server.pid"
+
+          # Check if the file exists
+          if [ -f "$file" ]
+          then
+              # Read PID
+              pid=$(cat "$file")
+
+              # Check if the PID exists
+              if ps -p $pid > /dev/null
+              then
+                  echo "Killing task with PID: $pid"
+                  kill $pid
+              else
+                  echo "No process found with PID: $pid"
+              fi
+              rm $file
+          else
+              echo "File $file does not exist"
+          fi
+
+
       - name: Start Biovalidator server (New schemas)
         if: ${{ env.version_needs_to_be_checked == 'True' }}
           # We want to specify the NEW JSON schemas, so we DO specify the schemas
           #   at deployment level
         run: |
-          schemas_dir="./schemas"          
+          schemas_dir="./schemas"
           node biovalidator/src/biovalidator -r "$schemas_dir/*.json" &
           sleep 3
 

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -18,11 +18,9 @@ name: |
   [REQUIRED] Check project version change
 
 on:
+  # Executes on any commit to a PR to the "main" branch
   pull_request:
     branches: [main]
-    # We only want for it to be triggered when JSON Schemas change in the PR
-    paths:
-      - 'schemas/**.json'
 
 jobs:
   check-modifications:
@@ -56,7 +54,7 @@ jobs:
         
         # The output of this previous script will determine if changes are not "major" (i.e. minor or patch), and therefore retrocompatibility
         #   has to be tested through JSON Schema validation (combination of old and new schemas with old and new examples).
-        #   Thus, only if the variable "version_needs_to_be_checked" from the script is True, the following steps will occur.
+        #   Thus, only if the output (saved at 'version_change') from the script is True, the following steps will occur.
 
         - name: Check if version change is Major
         id: check-version

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -58,7 +58,7 @@ jobs:
         
         # The output of this previous script will determine if changes are not "major" (i.e. minor or patch), and therefore retrocompatibility
         #   has to be tested through JSON Schema validation (combination of old and new schemas with old and new examples).
-        #   Thus, only if the output (saved at 'VERSION_CHANGE') from the script is True, the following steps will occur.
+        #   Thus, only if the output (saved at 'VERSION_CHANGE') from the script is NOT Major, the following steps will occur.
 
       - name: Check if version change is Major
         id: check-version

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   check-modifications:
     runs-on: ubuntu-latest
+    env:
+      BASE_URL: "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -50,29 +50,30 @@ jobs:
         id: run-version-modification-check
         run: |
           script_path="./.github/scripts/check_project_version_change.py"
-          version_change=$(python3 "$script_path")
+          python3 "$script_path" --git_var_name "VERSION_CHANGE"
+          echo "- The version change is: $VERSION_CHANGE"
         
         # The output of this previous script will determine if changes are not "major" (i.e. minor or patch), and therefore retrocompatibility
         #   has to be tested through JSON Schema validation (combination of old and new schemas with old and new examples).
-        #   Thus, only if the output (saved at 'version_change') from the script is True, the following steps will occur.
+        #   Thus, only if the output (saved at 'VERSION_CHANGE') from the script is True, the following steps will occur.
 
-        - name: Check if version change is Major
+      - name: Check if version change is Major
         id: check-version
           # This step is just to set the logic for triggering the following steps
         run: |
-          if [[ "${{ steps.run-version-modification-check.outputs.version_change }}" != "Major" ]]; then
-            echo "::set-output name=version_needs_to_be_checked::True"
+          if [[ "${{ env.VERSION_CHANGE }}" != "Major" ]]; then
+            echo "version_needs_to_be_checked=True" >> $GITHUB_ENV
           else
-            echo "::set-output name=version_needs_to_be_checked::False"
+            echo "version_needs_to_be_checked=False" >> $GITHUB_ENV
           fi
 
       - name: Clone Biovalidator
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
           # See https://github.com/elixir-europe/biovalidator#installation
         run: git clone https://github.com/elixir-europe/biovalidator.git
 
       - name: Install Biovalidator
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
         run: |
           cd biovalidator
           npm install
@@ -80,7 +81,7 @@ jobs:
           npm audit fix
 
       - name: Start Biovalidator server (old schemas)
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
           # We want to specify the OLD JSON schemas, so we DO NOT specify the schemas
           #   at deployment level, and instead let Biovalidator fetch them from "main"
         run: |
@@ -89,7 +90,7 @@ jobs:
           sleep 3
 
       - name: Validate JSON examples (old schemas, new examples)
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
           # Validate NEW JSON documents against the OLD (from "main") schemas
         run: |
           json_ex_dir="./examples/json_validation_tests"
@@ -99,7 +100,7 @@ jobs:
           python3 ./.github/scripts/request_validation.py "$json_ex_dir" "$url"
 
       - name: Start Biovalidator server (New schemas)
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
           # We want to specify the NEW JSON schemas, so we DO specify the schemas
           #   at deployment level
         run: |
@@ -108,7 +109,7 @@ jobs:
           sleep 3
 
       - name: Validate JSON examples (New schemas, old examples)
-        if: ${{ steps.check-version.outputs.version_needs_to_be_checked == 'True' }}
+        if: ${{ env.version_needs_to_be_checked == 'True' }}
           # Validate OLD JSON documents against the NEW (from branch) schemas
         run: |
           # We fetch all old JSON examples from "main"

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main"
+      REPOSITORY_URL: "https://api.github.com/repos/EbiEga/ega-metadata-schema"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check_project_version_change.yml
+++ b/.github/workflows/check_project_version_change.yml
@@ -48,13 +48,7 @@ jobs:
 
       - name: Run version modification check
         id: run-version-modification-check
-        run: |
-          #! Added for debugging purposes:
-          echo "Working directory: $(pwd)"
-          echo "Listing files in script directory:"
-          ls -la ./.github/scripts/
-          #! 
-          
+        run: |          
           script_path="./.github/scripts/check_project_version_change.py"
           python3 "$script_path" --git_var_name "VERSION_CHANGE" --verbose
           echo "- The version change is: $VERSION_CHANGE"

--- a/.github/workflows/json_validation_against_EGA_API.yml
+++ b/.github/workflows/json_validation_against_EGA_API.yml
@@ -14,7 +14,9 @@
 #
 # For more information, check:
 #   https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/gh_workflows
-name: JSON docs validation - EGA API (json_validation_against_EGA_API.yml)
+name: |
+  [OPTIONAL] JSON docs validation - 
+  EGA API (json_validation_against_EGA_API.yml)
 
 on:
   # Executes on any commit to a PR to the "main" branch

--- a/.github/workflows/json_validation_deploying_biovalidator.yml
+++ b/.github/workflows/json_validation_deploying_biovalidator.yml
@@ -23,7 +23,7 @@
 # For more information, check:
 #   https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/gh_workflows
 name: |
-  JSON docs validation - Local Biovalidator 
+  [REQUIRED] JSON docs validation - Local Biovalidator 
   (json_validation_deploying_biovalidator.yml)
 
 on:

--- a/.github/workflows/json_validation_deploying_biovalidator.yml
+++ b/.github/workflows/json_validation_deploying_biovalidator.yml
@@ -52,7 +52,7 @@ jobs:
           cd biovalidator
           npm install
           # We shouldn't need to audit the issues, but for now it is what it is
-          npm audit fix
+          # npm audit fix
 
       - name: Start Biovalidator server
           # We want to specify the JSON schemas and documents with the new 

--- a/.github/workflows/markdown_creation.yml
+++ b/.github/workflows/markdown_creation.yml
@@ -10,7 +10,9 @@
 #     events-that-trigger-workflows#running-your-workflow-when-a-pull-
 #     request-merges
 #   https://lannonbr.com/blog/2019-12-09-git-commit-in-actions
-name: JSON Schemas to Markdown (markdown_creation.yml)
+name: |
+  [OPTIONAL] JSON Schemas to Markdown (markdown_creation.yml)
+
 on:
   # A closed PR will imply a push to "main". After that push, this action
   #   executes, using as input the JSON schemas from "main".

--- a/.github/workflows/super_linter.yml
+++ b/.github/workflows/super_linter.yml
@@ -4,7 +4,8 @@
 #
 # For more information, check:
 #   https://github.com/github/super-linter
-name: Super-linter (super_linter.yml)
+name: |
+  [OPTIONAL] Super-linter (super_linter.yml)
 
 on:
   pull_request:

--- a/.github/workflows/update_version_manifest.yml
+++ b/.github/workflows/update_version_manifest.yml
@@ -12,7 +12,8 @@
 #
 # For more information, check:
 #   https://github.com/EbiEga/ega-metadata-schema/tree/main/docs/releases
-name: Version manifest update (update_version_manifest.yml)
+name: |
+  [REQUIRED] Version manifest update (update_version_manifest.yml)
 
 on:
   # Executes when opening a PR to the "main" branch

--- a/docs/releases/version_manifest.json
+++ b/docs/releases/version_manifest.json
@@ -17,21 +17,6 @@
                 "DAC": "0.0.0",
                 "protocol": "0.0.0",
                 "object-set": "0.0.0"
-            },
-            "allJsonSchemas": {
-                "common-definitions": "0.0.0",
-                "experiment": "0.0.0",
-                "study": "0.0.0",
-                "sample": "0.0.0",
-                "individual": "0.0.0",
-                "submission": "0.0.0",
-                "assay": "0.0.0",
-                "dataset": "0.0.0",
-                "analysis": "0.0.0",
-                "policy": "0.0.0",
-                "DAC": "0.0.0",
-                "protocol": "0.0.0",
-                "object-set": "0.0.0"
             }
         }
     ]

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -3,7 +3,7 @@
     "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.DAC.json",
     "type": "object",
     "title": "EGA DAC metadata schema",
-    "meta:version": "2.0.0",
+    "meta:version": "0.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Data Access Committee (DAC) metadata object. This object is intended to contain metadata about the body of one or more named individuals who are responsible for data release to external requestors based on consent and/or National Research Ethics terms. A DAC is typically formed, but not necessarily, from the same organization that collected the samples and generated any associated files/analyses. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/data_access_committee)",
     "required": ["objectId", "dacContacts"],

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -3,7 +3,7 @@
     "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.DAC.json",
     "type": "object",
     "title": "EGA DAC metadata schema",
-    "meta:version": "0.0.0",
+    "meta:version": "2.0.0",
     "$async": true,
     "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Data Access Committee (DAC) metadata object. This object is intended to contain metadata about the body of one or more named individuals who are responsible for data release to external requestors based on consent and/or National Research Ethics terms. A DAC is typically formed, but not necessarily, from the same organization that collected the samples and generated any associated files/analyses. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/data_access_committee)",
     "required": ["objectId", "dacContacts"],


### PR DESCRIPTION
## Ticket reference
[EE-2699](https://www.ebi.ac.uk/panda/jira/browse/EE-2699)

## Overall changes
- Added [**fetch_github_documents.py**](https://github.com/EbiEga/ega-metadata-schema/compare/main...M-casado:ega-metadata-schema:main?expand=1#diff-1d1117e473e414a2da1f045577e00b22b5bf33ce05ce8d27d539e54d985c82cd) in order to download files from the "main" repository. Alternatively this could have been done by checking out different branches within the GH repo, but I preferred not to download the whole thing, and just bits of it instead.
- Added script **[check_project_version_change.py](https://github.com/EbiEga/ega-metadata-schema/compare/main...M-casado:ega-metadata-schema:main?expand=1#diff-8b5571c9a0d07c24c17ea5d3414648bd89a86436dac6c9cb222e30947eef1967)** that **checks what is the semantic version change between the current branch name** (e.g. v1.0.0) and the last version in the [version_manifest.json](https://github.com/EbiEga/ega-metadata-schema/compare/main...M-casado:ega-metadata-schema:main?expand=1#diff-5c6ee2be1738b7efee4f7dd722af9bc60532dc36e2f546704e1b9582716ecafa) file. And based on it, it lets the GH workflow know the change type in order for it to test backwards compatibility.
- Added [check_project_version_change.yml](https://github.com/EbiEga/ega-metadata-schema/compare/main...M-casado:ega-metadata-schema:main?expand=1#diff-ae2e69108d6c146c1664518fce00b5416cc0746bffe934e39e64c93e9f8bc012) workflow that **calls the python script** and:
   - If the change between the last version of the release manifest is **lower or equal**, exits with an error.
   - If the change between the last version of the release manifest is **higher**:
      - If the change is **Major** (e.g. v0.0.0 --> v1.0.0), the workflow does not check backwards compatibility, since this is not expected.
      - If the change is **Minor or Patch** (e.g. v0.0.0 --> v0.1.0), the workflow checks **backwards compatibility** of the schemas and the examples by:
         - Testing the schemas from ``main`` (**old** schemas) with the examples from the branch (**new** examples).
         - Testing the schemas from the branch (**new** schemas) with the examples from ``main`` (**old** examples).
- Added functions to [git_manipulation.py](https://github.com/EbiEga/ega-metadata-schema/compare/main...M-casado:ega-metadata-schema:main?expand=1#diff-5dabfd931a65b18ce5a2c66df02721cd09662de19ad8ed66438d570e393f2f5c)
- Changed the names of all workflows (adding prefixes like ``[OPTIONAL]``) to identify them easier.
- Overall minor changes in code names and format.

The logic of checking backwards compatibility was the easiest route to check semantic versioning changes between JSON Schemas. I tried other alternatives and all seemed to be lacking or difficult to maintain. 

All of these things were **tested in my fork** of the repo in [this pr](https://github.com/M-casado/ega-metadata-schema/pull/12) and their associated PRs, which had different branch names for the purpose of testing.
## Future TO-DOs and checks
- [x] Check that the object's versions (i.e. ``meta:version``) are updated before creating the PR (see [GitHub Action](../.github/workflows/update_version_manifest.yml)). 
- [x] Check that the version manifest is up to date right before merging (see [documentation](../docs/releases/README.md#updating-the-version-manifest)). 
