### PR TITLE
EEH-2572 - Replaced bespoke patterns by "format"

### DIFF
--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that DAC EGA ID (EGAC) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGADACIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGADACIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -61,7 +61,7 @@
           "mainContact": {
             "title": "Main contact of the DAC",
             "description": "The main contact of that DAC whose contact details will be used first to reach the DAC.",
-            "$ref": "./EGA.common-definitions.json#/definitions/contactDetails"
+            "$ref": "./EGA.common-definitions.json#/$defs/contactDetails"
           },
           "additionalContacts": {
             "type": "array",
@@ -71,7 +71,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": { 
-              "$ref": "./EGA.common-definitions.json#/definitions/contactDetails" 
+              "$ref": "./EGA.common-definitions.json#/$defs/contactDetails" 
             }
           }
         }
@@ -88,7 +88,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a DAC",
@@ -98,15 +98,15 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetPolicy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetPolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         }
                       ]
                     }
@@ -118,23 +118,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDAC"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceDAC"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDAC"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetDAC"
                         }
                       ]
                     }
@@ -147,44 +147,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -196,7 +196,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -208,7 +208,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
 

--- a/schemas/EGA.DAC.json
+++ b/schemas/EGA.DAC.json
@@ -5,7 +5,7 @@
     "title": "EGA DAC metadata schema",
     "meta:version": "0.0.0",
     "$async": true,
-    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Data Access Committee (DAC) metadata object. This object is intended to contain metadata about the body of one or more named individuals who are responsible for data release to external requestors based on consent and/or National Research Ethics terms. A DAC is typically formed, but not necessarily, from the same organization that collected the samples and generated any associated files/analyses. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/data_access_committee)",
+    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to validate its Data Access Committee (DAC) metadata object. This object is intended to contain metadata about the body of one or more named individuals or legal entities who are data controllers. In other words, responsible for data release to external requestors based on consent and/or National Research Ethics terms. A DAC is typically formed, but not necessarily, from the same organization that collected the samples and generated any associated files/analyses. Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/submission/data_access_committee)",
     "required": ["objectId", "dacContacts"],
     "additionalProperties": false,
     "properties": {

--- a/schemas/EGA.analysis.json
+++ b/schemas/EGA.analysis.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that analysis EGA ID (EGAZ) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAAnalysisIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAAnalysisIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -59,7 +59,7 @@
         "uniqueItems": true,
         "additionalProperties": false,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/locusIdentifier" 
+          "$ref": "./EGA.common-definitions.json#/$defs/locusIdentifier" 
         }
       },
 
@@ -71,7 +71,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
+          "$ref": "./EGA.common-definitions.json#/$defs/typeOfData"
         }
       },
 
@@ -83,7 +83,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
+          "$ref": "./EGA.common-definitions.json#/$defs/typeOfData"
         }
       },
 
@@ -119,7 +119,7 @@
           "referenceAlignmentDetails": {
             "title": "Reference assembly and sequence details",
             "description": "Node containing details of the reference sequence used in the alignment of raw sequences.",
-            "$ref": "./EGA.common-definitions.json#/definitions/referenceAlignmentDetails"
+            "$ref": "./EGA.common-definitions.json#/$defs/referenceAlignmentDetails"
           }
         }
       },
@@ -132,7 +132,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-              "$ref": "./EGA.common-definitions.json#/definitions/fileObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/fileObject"
         }
       },
 
@@ -147,7 +147,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for an analysis",
@@ -157,34 +157,34 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         }
                       ]
                     }
@@ -196,23 +196,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         }
                       ]
                     }
@@ -225,44 +225,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -274,7 +274,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -286,7 +286,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that assay's EGA ID (EGAR) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAAssayIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAAssayIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -63,7 +63,7 @@
         "type": "string",
         "title": "Date of the assay",
         "description": "Date when the sequencing assay took place (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the assay concluded.",
-        "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
+        "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
       },
 
       "assayTypeSpecifications": {
@@ -110,7 +110,7 @@
                 "additionalProperties": false,
                 "uniqueItems": true,
                 "items": { 
-                  "$ref": "./EGA.common-definitions.json#/definitions/sampleLabelAssociation"
+                  "$ref": "./EGA.common-definitions.json#/$defs/sampleLabelAssociation"
                 }
               }
             },
@@ -165,7 +165,7 @@
               "referenceAlignmentDetails": {
                 "title": "Reference assembly and sequence details",
                 "description": "Node containing details of the reference sequence used in the alignment.",
-                "$ref": "./EGA.common-definitions.json#/definitions/referenceAlignmentDetails"
+                "$ref": "./EGA.common-definitions.json#/$defs/referenceAlignmentDetails"
               }
             }
           }
@@ -199,7 +199,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for an assay",
@@ -209,24 +209,24 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         }
                       ]
                     }
@@ -238,23 +238,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAssay"
                         }
                       ]
                     }
@@ -267,44 +267,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -316,7 +316,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -331,11 +331,11 @@
           "allOf": [
             {
               "title": "Basic file object",
-              "$ref": "./EGA.common-definitions.json#/definitions/fileObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/fileObject"
             },
             {
               "title": "Constraint of filetypes that are allowed for an assay",
-              "$ref": "./EGA.common-definitions.json#/definitions/assayFiletypes"
+              "$ref": "./EGA.common-definitions.json#/$defs/assayFiletypes"
             }
           ]              
         }
@@ -349,7 +349,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
 

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -64,7 +64,7 @@
         "title": "Date of the assay",
         "description": "Date when the sequencing assay took place (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the assay concluded.",
         "format": "date",
-        "examples": [ "2021-04-30", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
+        "examples": [ "2021-04-30", "2020-12-29" ]
       },
 
       "assayTypeSpecifications": {

--- a/schemas/EGA.assay.json
+++ b/schemas/EGA.assay.json
@@ -63,7 +63,8 @@
         "type": "string",
         "title": "Date of the assay",
         "description": "Date when the sequencing assay took place (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the assay concluded.",
-        "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
+        "format": "date",
+        "examples": [ "2021-04-30", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
       },
 
       "assayTypeSpecifications": {

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -748,14 +748,6 @@
         "examples": [ "EGAO00001159483" ]
       },
       
-      "EGAISO8601DurationPattern": {
-        "type": "string",
-        "title": "Pattern of a partial EGA ISO 8601 duration",
-        "description": "Pattern of ISO 8601 durations. It can be used to define time intervals (e.g. 'P3Y6M4DT12H30M5S' represents a duration of three years, six months, four days, twelve hours, thirty minutes, and five seconds). See more at https://en.wikipedia.org/wiki/ISO_8601#Durations.",
-        "pattern": "^[-+]?P(?!$)(([-+]?\\d+Y)|([-+]?\\d+\\.\\d+Y$))?(([-+]?\\d+M)|([-+]?\\d+\\.\\d+M$))?(([-+]?\\d+W)|([-+]?\\d+\\.\\d+W$))?(([-+]?\\d+D)|([-+]?\\d+\\.\\d+D$))?(T(?=[\\d+-])(([-+]?\\d+H)|([-+]?\\d+\\.\\d+H$))?(([-+]?\\d+M)|([-+]?\\d+\\.\\d+M$))?([-+]?\\d+(\\.\\d+)?S)?)??$",
-        "examples": [ "P3Y6M4DT12H30M5S", "P23DT23H", "PT0S", "P0D", "P0,5Y", "P0.5Y"]
-      },
-
       "filenameFiletypePatternCheck": {
         "type": "object",
         "title": "Check: filetype checks based on its filename",
@@ -3706,13 +3698,8 @@
         "title": "Individual's age",
         "meta:propertyCurie": "EFO:0000246",
         "description": "Precise age in ISO8601 format of the individual. For example, 'P3Y6M4D' represents a duration of three years, six months and four days.",
-        "allOf": [
-          {
-            "title": "ISO8601 Date pattern",
-            "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DurationPattern"
-          }
-        ],
-        "examples": [ "P3Y6M4D", "P23DT23H", "P4Y" ]
+        "format": "",
+        "examples": [ "P3Y6M4D", "P4Y", "P23DT23H", "PT0S", "P0D", "P0,5Y", "P0.5Y"]
       },
 
       "cellType": {

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -5,8 +5,8 @@
     "title": "EGA common metadata definitions",
     "meta:version": "0.0.0",
     "$async": true,
-    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to store common definitions for other metadata objects. Basically, we are defining here common properties (e.g. instances' aliases) that other metadata objects (e.g. sample) may use. The way we refer to them is by using this object's '$id' field, referencing it in other files (with '$ref' and the relative path of the property - e.g. '$ref': 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/definitions/objectCoreId'). See structuring documentation (https://json-schema.org/understanding-json-schema/structuring.html). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
-    "definitions": {
+    "description": "Metadata schema used by the European Genome-phenome Archive (EGA) to store common definitions for other metadata objects. Basically, we are defining here common properties (e.g. instances' aliases) that other metadata objects (e.g. sample) may use. The way we refer to them is by using this object's '$id' field, referencing it in other files (with '$ref' and the relative path of the property - e.g. '$ref': 'https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas/EGA.common-definitions.json#/$defs/objectCoreId'). See structuring documentation (https://json-schema.org/understanding-json-schema/structuring.html). Further details can be found in the EGA-metadata-schema GitHub repository (https://github.com/EbiEga/ega-metadata-schema/tree/main/schemas) and EGA-archive website (https://ega-archive.org/)",
+    "$defs": {
       "objectCoreId": {
         "type": "object",
         "title": "Core identifiers of an object",
@@ -41,7 +41,7 @@
             "additionalProperties": false,
             "uniqueItems": true,
             "items": {
-              "$ref": "./EGA.common-definitions.json#/definitions/objectExternalAccession"
+              "$ref": "./EGA.common-definitions.json#/$defs/objectExternalAccession"
             }
           }
 
@@ -122,7 +122,7 @@
               "allOf": [
                 {
                   "title": "Inherited ontologyTerm structure of termId and termLabel",
-                  "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                  "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
                 }
               ],
               "properties": {        
@@ -240,11 +240,11 @@
             "oneOf": [
               { 
                 "title": "Check of MD5 checksum pattern", 
-                "$ref": "#/definitions/md5ChecksumPattern"
+                "$ref": "#/$defs/md5ChecksumPattern"
               },
               { 
                 "title": "Check of SHA-256 checksum pattern",
-                "$ref": "#/definitions/SHA256ChecksumPattern"
+                "$ref": "#/$defs/SHA256ChecksumPattern"
               }
             ]
           },
@@ -256,11 +256,11 @@
             "oneOf": [
               { 
                 "title": "Check of MD5 checksum pattern", 
-                "$ref": "#/definitions/md5ChecksumPattern"
+                "$ref": "#/$defs/md5ChecksumPattern"
               },
               { 
                 "title": "Check of SHA-256 checksum pattern",
-                "$ref": "#/definitions/SHA256ChecksumPattern"
+                "$ref": "#/$defs/SHA256ChecksumPattern"
               }
             ]
           },
@@ -308,11 +308,11 @@
         "allOf": [
           { 
             "title": "Inherited check of checksum patterns", 
-            "$ref": "#/definitions/checksumPatternCheck" 
+            "$ref": "#/$defs/checksumPatternCheck" 
           },
           { 
             "title": "Inherited check of filetype-filename patterns", 
-            "$ref": "#/definitions/filenameFiletypePatternCheck" 
+            "$ref": "#/$defs/filenameFiletypePatternCheck" 
           }
         ]        
       },
@@ -352,7 +352,7 @@
             "allOf": [
               {
                 "title": "Inherited oneRelationshipEnd object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/oneRelationshipEnd" 
+                "$ref": "./EGA.common-definitions.json#/$defs/oneRelationshipEnd" 
               }
             ]
           },
@@ -363,7 +363,7 @@
             "allOf": [
               {
                 "title": "Inherited oneRelationshipEnd object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/oneRelationshipEnd" 
+                "$ref": "./EGA.common-definitions.json#/$defs/oneRelationshipEnd" 
               }
             ]
           },
@@ -412,7 +412,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -474,7 +474,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAExperimentIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAExperimentIdPattern" }
                 }
               },
               "objectType": {
@@ -488,7 +488,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAStudyIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAStudyIdPattern" }
                 }
               },
               "objectType": {
@@ -502,7 +502,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGASampleIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGASampleIdPattern" }
                 }
               },
               "objectType": {
@@ -516,7 +516,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGASubmissionIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGASubmissionIdPattern" }
                 }
               },
               "objectType": {
@@ -530,7 +530,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAAssayIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAAssayIdPattern" }
                 }
               },
               "objectType": {
@@ -544,7 +544,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGADatasetIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGADatasetIdPattern" }
                 }
               },
               "objectType": {
@@ -558,7 +558,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAAnalysisIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAAnalysisIdPattern" }
                 }
               },
               "objectType": {
@@ -572,7 +572,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAPolicyIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAPolicyIdPattern" }
                 }
               },
               "objectType": {
@@ -586,7 +586,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGADACIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGADACIdPattern" }
                 }
               },
               "objectType": {
@@ -600,7 +600,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAIndividualIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAIndividualIdPattern" }
                 }
               },
               "objectType": {
@@ -614,7 +614,7 @@
             "properties": {
               "objectId": { 
                 "properties": {
-                  "egaAccession": { "$ref": "#/definitions/EGAProtocolIdPattern" }
+                  "egaAccession": { "$ref": "#/$defs/EGAProtocolIdPattern" }
                 }
               },
               "objectType": {
@@ -637,8 +637,8 @@
                 "checksumMethod": {
                       "enum": ["MD5"]
                 },
-                "unencryptedChecksum": { "$ref": "#/definitions/md5ChecksumPattern" },
-                "encryptedChecksum": { "$ref": "#/definitions/md5ChecksumPattern" }
+                "unencryptedChecksum": { "$ref": "#/$defs/md5ChecksumPattern" },
+                "encryptedChecksum": { "$ref": "#/$defs/md5ChecksumPattern" }
               }
           },
           { 
@@ -648,8 +648,8 @@
                 "checksumMethod": {
                       "enum": ["SHA-256"]
                 },
-                "unencryptedChecksum": { "$ref": "#/definitions/SHA256ChecksumPattern" },
-                "encryptedChecksum": { "$ref": "#/definitions/SHA256ChecksumPattern" }
+                "unencryptedChecksum": { "$ref": "#/$defs/SHA256ChecksumPattern" },
+                "encryptedChecksum": { "$ref": "#/$defs/SHA256ChecksumPattern" }
               }
           }
         ]                    
@@ -775,7 +775,7 @@
                 "filetype": {
                    "enum": ["CEL"] 
                 },
-                "filename": { "$ref": "#/definitions/celFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/celFileFilenamePattern" }
             }
           },                
           {
@@ -784,7 +784,7 @@
                 "filetype": {
                    "enum": ["TSV"] 
                 },
-                "filename": { "$ref": "#/definitions/tsvFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/tsvFileFilenamePattern" }
             }
           },                
           {
@@ -793,7 +793,7 @@
                 "filetype": {
                    "enum": ["ADF"] 
                 },
-                "filename": { "$ref": "#/definitions/adfFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/adfFileFilenamePattern" }
             }
           },                
           {
@@ -802,7 +802,7 @@
                 "filetype": {
                    "enum": ["FASTQ"] 
                 },
-                "filename": { "$ref": "#/definitions/fastqFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/fastqFileFilenamePattern" }
             }
           },                
           {
@@ -811,7 +811,7 @@
                 "filetype": {
                    "enum": ["FASTA"] 
                 },
-                "filename": { "$ref": "#/definitions/fastaFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/fastaFileFilenamePattern" }
             }
           },                
           {
@@ -820,7 +820,7 @@
                 "filetype": {
                    "enum": ["SDRF"] 
                 },
-                "filename": { "$ref": "#/definitions/sdrfFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/sdrfFileFilenamePattern" }
             }
           },                
           {
@@ -829,7 +829,7 @@
                 "filetype": {
                    "enum": ["IDF"] 
                 },
-                "filename": { "$ref": "#/definitions/idfFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/idfFileFilenamePattern" }
             }
           },                
           {
@@ -838,7 +838,7 @@
                 "filetype": {
                    "enum": ["VCF"] 
                 },
-                "filename": { "$ref": "#/definitions/vcfFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/vcfFileFilenamePattern" }
             }
           },                
           {
@@ -847,7 +847,7 @@
                 "filetype": {
                    "enum": ["SRA"] 
                 },
-                "filename": { "$ref": "#/definitions/sraFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/sraFileFilenamePattern" }
             }
           },                
           {
@@ -856,7 +856,7 @@
                 "filetype": {
                    "enum": ["SRF"] 
                 },
-                "filename": { "$ref": "#/definitions/srfFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/srfFileFilenamePattern" }
             }
           },                
           {
@@ -865,7 +865,7 @@
                 "filetype": {
                    "enum": ["SFF"] 
                 },
-                "filename": { "$ref": "#/definitions/sffFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/sffFileFilenamePattern" }
             }
           },                
           {
@@ -874,7 +874,7 @@
                 "filetype": {
                    "enum": ["BAM"] 
                 },
-                "filename": { "$ref": "#/definitions/bamFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/bamFileFilenamePattern" }
             }
           },                
           {
@@ -883,7 +883,7 @@
                 "filetype": {
                    "enum": ["CRAM"] 
                 },
-                "filename": { "$ref": "#/definitions/cramFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/cramFileFilenamePattern" }
             }
           },                
           {
@@ -892,7 +892,7 @@
                 "filetype": {
                    "enum": ["XLSX"] 
                 },
-                "filename": { "$ref": "#/definitions/xlsxFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/xlsxFileFilenamePattern" }
             }
           },                
           {
@@ -901,7 +901,7 @@
                 "filetype": {
                    "enum": ["CSV"] 
                 },
-                "filename": { "$ref": "#/definitions/csvFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/csvFileFilenamePattern" }
             }
           },                
           {
@@ -910,7 +910,7 @@
                 "filetype": {
                    "enum": ["BED"] 
                 },
-                "filename": { "$ref": "#/definitions/bedFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/bedFileFilenamePattern" }
             }
           },                
           {
@@ -919,7 +919,7 @@
                 "filetype": {
                    "enum": ["IDAT"] 
                 },
-                "filename": { "$ref": "#/definitions/idatFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/idatFileFilenamePattern" }
             }
           },                
           {
@@ -928,7 +928,7 @@
                 "filetype": {
                    "enum": ["MAP"] 
                 },
-                "filename": { "$ref": "#/definitions/mapFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/mapFileFilenamePattern" }
             }
           },                
           {
@@ -937,7 +937,7 @@
                 "filetype": {
                    "enum": ["PED"] 
                 },
-                "filename": { "$ref": "#/definitions/pedFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/pedFileFilenamePattern" }
             }
           },                
           {
@@ -946,7 +946,7 @@
                 "filetype": {
                    "enum": ["BIM"] 
                 },
-                "filename": { "$ref": "#/definitions/bimFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/bimFileFilenamePattern" }
             }
           },                
           {
@@ -955,7 +955,7 @@
                 "filetype": {
                    "enum": ["FAM"] 
                 },
-                "filename": { "$ref": "#/definitions/famFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/famFileFilenamePattern" }
             }
           },
           {
@@ -964,7 +964,7 @@
                 "filetype": {
                    "enum": ["TXT"] 
                 },
-                "filename": { "$ref": "#/definitions/txtFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/txtFileFilenamePattern" }
             }
           },
           {
@@ -973,7 +973,7 @@
                 "filetype": {
                    "enum": ["EXP"] 
                 },
-                "filename": { "$ref": "#/definitions/expFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/expFileFilenamePattern" }
             }
           },
           {
@@ -982,7 +982,7 @@
                 "filetype": {
                    "enum": ["GPR"] 
                 },
-                "filename": { "$ref": "#/definitions/gprFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/gprFileFilenamePattern" }
             }
           },
           {
@@ -991,7 +991,7 @@
                 "filetype": {
                    "enum": ["PY"] 
                 },
-                "filename": { "$ref": "#/definitions/pyFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/pyFileFilenamePattern" }
             }
           },
           {
@@ -1000,7 +1000,7 @@
                 "filetype": {
                    "enum": ["SH"] 
                 },
-                "filename": { "$ref": "#/definitions/shFileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/shFileFilenamePattern" }
             }
           },
           {
@@ -1009,7 +1009,7 @@
                 "filetype": {
                     "enum": ["MD5"]
                 },
-                "filename": { "$ref": "#/definitions/md5FileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/md5FileFilenamePattern" }
             }
           },
           {
@@ -1018,7 +1018,7 @@
                   "filetype": {
                       "enum": ["HAP"]
                   },
-                  "filename": { "$ref": "#/definitions/hapFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/hapFileFilenamePattern" }
               }
           },
           {
@@ -1027,7 +1027,7 @@
                   "filetype": {
                       "enum": ["CSFASTA"]
                   },
-                  "filename": { "$ref": "#/definitions/csfastaFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/csfastaFileFilenamePattern" }
               }
           },
           {
@@ -1036,7 +1036,7 @@
                   "filetype": {
                       "enum": ["LOC"]
                   },
-                  "filename": { "$ref": "#/definitions/locFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/locFileFilenamePattern" }
               }
           },
           {
@@ -1045,7 +1045,7 @@
                   "filetype": {
                       "enum": ["HTML"]
                   },
-                  "filename": { "$ref": "#/definitions/htmlFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/htmlFileFilenamePattern" }
               }
           },
           {
@@ -1054,7 +1054,7 @@
                   "filetype": {
                       "enum": ["HIC"]
                   },
-                  "filename": { "$ref": "#/definitions/hicFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/hicFileFilenamePattern" }
               }
           },
           {
@@ -1063,7 +1063,7 @@
                   "filetype": {
                       "enum": ["MD"]
                   },
-                  "filename": { "$ref": "#/definitions/mdFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/mdFileFilenamePattern" }
               }
           },
           {
@@ -1072,7 +1072,7 @@
                   "filetype": {
                       "enum": ["MATLAB"]
                   },
-                  "filename": { "$ref": "#/definitions/matlabFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/matlabFileFilenamePattern" }
               }
           },
           {
@@ -1081,7 +1081,7 @@
                   "filetype": {
                       "enum": ["PERL"]
                   },
-                  "filename": { "$ref": "#/definitions/perlFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/perlFileFilenamePattern" }
               }
           },
           {
@@ -1090,7 +1090,7 @@
                   "filetype": {
                       "enum": ["TIF"]
                   },
-                  "filename": { "$ref": "#/definitions/tifFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/tifFileFilenamePattern" }
               }
           },
           {
@@ -1099,7 +1099,7 @@
                   "filetype": {
                       "enum": ["R"]
                   },
-                  "filename": { "$ref": "#/definitions/rFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/rFileFilenamePattern" }
               }
           },
           {
@@ -1108,7 +1108,7 @@
                   "filetype": {
                       "enum": ["SNP"]
                   },
-                  "filename": { "$ref": "#/definitions/snpFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/snpFileFilenamePattern" }
               }
           },
           {
@@ -1117,7 +1117,7 @@
                   "filetype": {
                       "enum": ["XML"]
                   },
-                  "filename": { "$ref": "#/definitions/xmlFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/xmlFileFilenamePattern" }
               }
           },
           {
@@ -1126,7 +1126,7 @@
                   "filetype": {
                       "enum": ["SVG"]
                   },
-                  "filename": { "$ref": "#/definitions/svgFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/svgFileFilenamePattern" }
               }
           },
           {
@@ -1135,7 +1135,7 @@
                   "filetype": {
                       "enum": ["PNG"]
                   },
-                  "filename": { "$ref": "#/definitions/pngFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/pngFileFilenamePattern" }
               }
           },
           {
@@ -1144,7 +1144,7 @@
                   "filetype": {
                       "enum": ["JPG"]
                   },
-                  "filename": { "$ref": "#/definitions/jpgFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/jpgFileFilenamePattern" }
               }
           },
           {
@@ -1153,7 +1153,7 @@
                   "filetype": {
                       "enum": ["GTC"]
                   },
-                  "filename": { "$ref": "#/definitions/gtcFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/gtcFileFilenamePattern" }
               }
           },
           {
@@ -1162,7 +1162,7 @@
                   "filetype": {
                       "enum": ["HDF5"]
                   },
-                  "filename": { "$ref": "#/definitions/hdf5FileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/hdf5FileFilenamePattern" }
               }
           },
           {
@@ -1171,7 +1171,7 @@
                 "filetype": {
                     "enum": ["FAST5"]
                 },
-                "filename": { "$ref": "#/definitions/fast5FileFilenamePattern" }
+                "filename": { "$ref": "#/$defs/fast5FileFilenamePattern" }
             }
           },
           {
@@ -1180,7 +1180,7 @@
                   "filetype": {
                       "enum": ["PAIR"]
                   },
-                  "filename": { "$ref": "#/definitions/pairFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/pairFileFilenamePattern" }
               }
           },
           {
@@ -1189,7 +1189,7 @@
                   "filetype": {
                       "enum": ["TXT"]
                   },
-                  "filename": { "$ref": "#/definitions/txtFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/txtFileFilenamePattern" }
               }
           },
           {
@@ -1198,7 +1198,7 @@
                   "filetype": {
                       "enum": ["BGI"]
                   },
-                  "filename": { "$ref": "#/definitions/bgiFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/bgiFileFilenamePattern" }
               }
           },
           {
@@ -1207,7 +1207,7 @@
                   "filetype": {
                       "enum": ["BGEN"]
                   },
-                  "filename": { "$ref": "#/definitions/bgenFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/bgenFileFilenamePattern" }
               }
           },
           {
@@ -1216,7 +1216,7 @@
                   "filetype": {
                       "enum": ["GEN"]
                   },
-                  "filename": { "$ref": "#/definitions/genFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/genFileFilenamePattern" }
               }
           },
           {
@@ -1225,7 +1225,7 @@
                   "filetype": {
                       "enum": ["PXF"]
                   },
-                  "filename": { "$ref": "#/definitions/pxfFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/pxfFileFilenamePattern" }
               }
           },
           {
@@ -1234,7 +1234,7 @@
                   "filetype": {
                       "enum": ["LOOM"]
                   },
-                  "filename": { "$ref": "#/definitions/loomFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/loomFileFilenamePattern" }
               }
           },
           {
@@ -1243,7 +1243,7 @@
                   "filetype": {
                       "enum": ["BAX.H5"]
                   },
-                  "filename": { "$ref": "#/definitions/bax.h5FileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/bax.h5FileFilenamePattern" }
               }
           },
           {
@@ -1252,7 +1252,7 @@
                   "filetype": {
                       "enum": ["BAS.H5"]
                   },
-                  "filename": { "$ref": "#/definitions/bas.h5FileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/bas.h5FileFilenamePattern" }
               }
           },
           {
@@ -1261,7 +1261,7 @@
                   "filetype": {
                       "enum": ["ASM"]
                   },
-                  "filename": { "$ref": "#/definitions/asmFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/asmFileFilenamePattern" }
               }
           },
           {
@@ -1270,7 +1270,7 @@
                   "filetype": {
                       "enum": ["CSI"]
                   },
-                  "filename": { "$ref": "#/definitions/csiFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/csiFileFilenamePattern" }
               }
           },
           {
@@ -1279,7 +1279,7 @@
                   "filetype": {
                       "enum": ["TBI"]
                   },
-                  "filename": { "$ref": "#/definitions/tbiFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/tbiFileFilenamePattern" }
               }
           },
           {
@@ -1288,7 +1288,7 @@
                   "filetype": {
                       "enum": ["BCF"]
                   },
-                  "filename": { "$ref": "#/definitions/bcfFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/bcfFileFilenamePattern" }
               }
           },
           {
@@ -1297,7 +1297,7 @@
                   "filetype": {
                       "enum": ["qual454"]
                   },
-                  "filename": { "$ref": "#/definitions/qual454FileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/qual454FileFilenamePattern" }
               }
           },
           {
@@ -1306,7 +1306,7 @@
                   "filetype": {
                       "enum": ["qualsolid"]
                   },
-                  "filename": { "$ref": "#/definitions/qualsolidFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/qualsolidFileFilenamePattern" }
               }
           },
           {
@@ -1315,7 +1315,7 @@
                   "filetype": {
                       "enum": ["FASTQ-illumina"]
                   },
-                  "filename": { "$ref": "#/definitions/fastqIlluminaFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/fastqIlluminaFileFilenamePattern" }
               }
           },
           {
@@ -1324,7 +1324,7 @@
                   "filetype": {
                       "enum": ["FASTQ-helicos"]
                   },
-                  "filename": { "$ref": "#/definitions/fastqHelicosFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/fastqHelicosFileFilenamePattern" }
               }
           },
           {
@@ -1333,7 +1333,7 @@
                   "filetype": {
                       "enum": ["FASTQ-sanger"]
                   },
-                  "filename": { "$ref": "#/definitions/fastqSangerFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/fastqSangerFileFilenamePattern" }
               }
           },
           {
@@ -1342,7 +1342,7 @@
                   "filetype": {
                       "enum": ["FASTQ-solexa"]
                   },
-                  "filename": { "$ref": "#/definitions/fastqSolexaFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/fastqSolexaFileFilenamePattern" }
               }
           },
           {
@@ -1351,7 +1351,7 @@
                   "filetype": {
                       "enum": ["SAM"]
                   },
-                  "filename": { "$ref": "#/definitions/samFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/samFileFilenamePattern" }
               }
           },
           {
@@ -1360,7 +1360,7 @@
                   "filetype": {
                       "enum": ["CRAI"]
                   },
-                  "filename": { "$ref": "#/definitions/craiFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/craiFileFilenamePattern" }
               }
           },
           {
@@ -1369,7 +1369,7 @@
                   "filetype": {
                       "enum": ["BAI"]
                   },
-                  "filename": { "$ref": "#/definitions/baiFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/baiFileFilenamePattern" }
               }
           },
           {
@@ -1378,7 +1378,7 @@
                   "filetype": {
                       "enum": ["MTX"]
                   },
-                  "filename": { "$ref": "#/definitions/mtxFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/mtxFileFilenamePattern" }
               }
           },
           {
@@ -1387,7 +1387,7 @@
                   "filetype": {
                       "enum": ["MEX"]
                   },
-                  "filename": { "$ref": "#/definitions/mexFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/mexFileFilenamePattern" }
               }
           },
           {
@@ -1396,7 +1396,7 @@
                   "filetype": {
                       "enum": ["GMX"]
                   },
-                  "filename": { "$ref": "#/definitions/gmxFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/gmxFileFilenamePattern" }
               }
           },
           {
@@ -1405,7 +1405,7 @@
                   "filetype": {
                       "enum": ["GMT"]
                   },
-                  "filename": { "$ref": "#/definitions/gmtFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/gmtFileFilenamePattern" }
               }
           },
           {
@@ -1414,7 +1414,7 @@
                   "filetype": {
                       "enum": ["GRP"]
                   },
-                  "filename": { "$ref": "#/definitions/grpFileFilenamePattern" }
+                  "filename": { "$ref": "#/$defs/grpFileFilenamePattern" }
               }
           }
         ]        
@@ -2086,7 +2086,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ]
           },
@@ -2097,7 +2097,7 @@
             "allOf": [
               {
                 "title": "General pattern of a URL/URI",
-                "$ref": "./EGA.common-definitions.json#/definitions/urlUriPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/urlUriPattern"
               }
             ],
             "examples": [ 
@@ -2139,7 +2139,7 @@
         "properties": {
           "arrayLabel": { 
             "title": "Labelling dye used with the sample",
-            "$ref": "./EGA.common-definitions.json#/definitions/arrayLabel" 
+            "$ref": "./EGA.common-definitions.json#/$defs/arrayLabel" 
           },
           "objectId": {
             "type": "object",
@@ -2147,13 +2147,13 @@
             "allOf": [
               {
                 "title": "Inherited objectCoreId object",
-                "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+                "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
               },
               {
                 "title": "Check that sample EGA ID (EGAN) pattern is correct",
                 "properties": {
                   "egaAccession": {
-                    "$ref": "./EGA.common-definitions.json#/definitions/EGASampleIdPattern"
+                    "$ref": "./EGA.common-definitions.json#/$defs/EGASampleIdPattern"
                   }
                 }
               }
@@ -2172,11 +2172,11 @@
           "objectId": {
             "type": "object",
             "title": "Relationship's object's IDs block",
-            "description": "Node containing the main identifiers of the relationship's object (e.g. alias, centerName...), inherited from the common definitions (#/definitions/objectCoreId).",
+            "description": "Node containing the main identifiers of the relationship's object (e.g. alias, centerName...), inherited from the common definitions (#/$defs/objectCoreId).",
             "allOf": [
               { 
                 "title": "Inherited objectCoreId object", 
-                "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId" 
+                "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId" 
               }
             ]
           },
@@ -2206,7 +2206,7 @@
         "allOf": [
           { 
             "title": "Check for objectId and objectType to match",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectIdAndObjectTypeCheck" 
+            "$ref": "./EGA.common-definitions.json#/$defs/objectIdAndObjectTypeCheck" 
           }
         ]        
       },
@@ -2250,7 +2250,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -2298,7 +2298,7 @@
             "allOf": [
               {
                 "title": "General pattern of a URL/URI",
-                "$ref": "./EGA.common-definitions.json#/definitions/urlUriPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/urlUriPattern"
               }
             ],
             "examples": ["https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json"]
@@ -2310,7 +2310,7 @@
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/semanticVersioningPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/semanticVersioningPattern"
               }
             ]
           },
@@ -2321,7 +2321,7 @@
             "allOf": [
               {
                 "title": "Check semantic versioning pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/semanticVersioningPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/semanticVersioningPattern"
               }
             ]
           }
@@ -2451,7 +2451,7 @@
           "organismDescriptor": {
             "title": "Organism descriptor",
             "description": "Node to identify the specific organism the locus belongs to.",
-            "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
+            "$ref": "./EGA.common-definitions.json#/$defs/organismDescriptor"
           },
           "lociDescriptor": {
             "type": "array",
@@ -2468,17 +2468,17 @@
                 "geneDescriptor": {
                   "title": "Gene descriptor",
                   "description": "Node to identify the gene of the locus of interest.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/geneDescriptor"
+                  "$ref": "./EGA.common-definitions.json#/$defs/geneDescriptor"
                 },
                 "genomicSequenceDescriptor": {
                   "title": "Genomic sequence descriptor",
                   "description": "Node to describe the sequence per se, instead of referencing it.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/genomicSequenceDescriptor"
+                  "$ref": "./EGA.common-definitions.json#/$defs/genomicSequenceDescriptor"
                 },
                 "locusExternalReference": {
                   "title": "External reference of the locus",
                   "description": "If the locus can not be identified by a gene (if so, use 'geneDescriptor'), and it is well represented (i.e. uniquely identifiable and with comprehensive detail) in another resource that is accessible and persistent, one can reference it here instead of providing all their details. In other words, one can reference here ways to access the locus information that is accessible elsewhere. For example miRNA 'MI0039740' (mirbase:MI0039740) that lacks a gene descriptor.",
-                  "$ref": "./EGA.common-definitions.json#/definitions/objectExternalAccession"
+                  "$ref": "./EGA.common-definitions.json#/$defs/objectExternalAccession"
                 },
                 "locusAdditionalDescription": {
                   "type": "string",
@@ -2522,7 +2522,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -2531,11 +2531,11 @@
                 "anyOf": [
                   {
                     "title": "NCBI Gene pattern (e.g. 'NCBIGene:100010')",
-                    "$ref": "./EGA.common-definitions.json#/definitions/curieNcbiGeneIdentifierPattern"
+                    "$ref": "./EGA.common-definitions.json#/$defs/curieNcbiGeneIdentifierPattern"
                   },
                   {
                     "title": "HGNC Gene pattern (e.g. 'hgnc:2674')",
-                    "$ref": "./EGA.common-definitions.json#/definitions/curieHgncIdentifierPattern"
+                    "$ref": "./EGA.common-definitions.json#/$defs/curieHgncIdentifierPattern"
                   }
                 ],
                 "examples": [ "NCBIGene:100010", "hgnc:2674" ]
@@ -2566,7 +2566,7 @@
               "allOf": [
                 {
                   "title": "Inherited ontologyTerm structure of termId and termLabel",
-                  "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                  "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
                 }
               ]
             }
@@ -2585,7 +2585,7 @@
               "allOf": [
                 {
                   "title": "Inherited ontologyTerm structure of termId and termLabel",
-                  "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                  "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
                 }
               ]            
             }
@@ -2608,7 +2608,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -2617,7 +2617,7 @@
                 "allOf": [
                   {
                     "title": "NCBI's assembly CURIE pattern",
-                    "$ref": "./EGA.common-definitions.json#/definitions/curieNcbiAssemblyPattern"
+                    "$ref": "./EGA.common-definitions.json#/$defs/curieNcbiAssemblyPattern"
                   }
                 ],
                 "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
@@ -2631,7 +2631,7 @@
                 "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -2655,20 +2655,20 @@
             "title": "Assembly descriptor",
             "meta:propertyCurie": "topic:0196",
             "description": "Node to identify the assembly of the locus of interest.",
-            "$ref": "./EGA.common-definitions.json#/definitions/ncbiAssemblyDescriptor"
+            "$ref": "./EGA.common-definitions.json#/$defs/ncbiAssemblyDescriptor"
           },
           "sequenceCoordinates": {
             "title": "DNA Sequence coordinates",
             "description": "Node to define que specific sequence coordinates of the genomic feature within the assembly.",
-            "$ref": "./EGA.common-definitions.json#/definitions/sequenceCoordinates"
+            "$ref": "./EGA.common-definitions.json#/$defs/sequenceCoordinates"
           },
           "dnaSequenceStrand": {
             "title": "DNA Sequence strand",
-            "$ref": "./EGA.common-definitions.json#/definitions/dnaSequenceStrand"
+            "$ref": "./EGA.common-definitions.json#/$defs/dnaSequenceStrand"
           },
           "nucleicAcidSequence": {
             "title": "Nucleic acid sequence of the locus",
-            "$ref": "./EGA.common-definitions.json#/definitions/nucleicAcidSequence"
+            "$ref": "./EGA.common-definitions.json#/$defs/nucleicAcidSequence"
           }
         },
         "anyOf": [
@@ -2692,7 +2692,7 @@
         "properties": {
           "singlePosition": {
             "title": "Single position",
-            "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
+            "$ref": "./EGA.common-definitions.json#/$defs/singleSequencePosition"
           },
           "sequenceInterval": {
             "type": "object",
@@ -2704,11 +2704,11 @@
             "properties": {
               "start": {
                 "title": "Start position",
-                "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
+                "$ref": "./EGA.common-definitions.json#/$defs/singleSequencePosition"
               },
               "end": {
                 "title": "End position",
-                "$ref": "./EGA.common-definitions.json#/definitions/singleSequencePosition"
+                "$ref": "./EGA.common-definitions.json#/$defs/singleSequencePosition"
               }
             }
           }
@@ -2770,7 +2770,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
           }
         ],        
         "oneOf": [
@@ -2861,7 +2861,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
           }
         ],
         "examples": ["hgnc.symbol:DAPK1", "hgnc.symbol:TAF1"]
@@ -2875,7 +2875,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
           }
         ],
         "examples": ["hgnc:2674", "HGNC:11535"]
@@ -2889,7 +2889,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
           }
         ],
         "examples": ["ncbigene:100010", "ncbigene:270627"]
@@ -2903,7 +2903,7 @@
         "allOf": [
           {
             "title": "General CURIE pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
           }
         ],
         "examples": ["assembly:GCF_000001405.26", "assembly:GCA_000001405.1", "assembly:GCF_000005845.2" ]
@@ -3146,7 +3146,7 @@
         "minItems": 1,
         "items": {
           "title": "One item containing metadata of the assembly or assembly unit.",
-          "$ref": "./EGA.common-definitions.json#/definitions/ncbiAssemblyDescriptor"
+          "$ref": "./EGA.common-definitions.json#/$defs/ncbiAssemblyDescriptor"
         }
       },
 
@@ -3158,7 +3158,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {        
@@ -3693,10 +3693,10 @@
         "description": "This node defines a relationship item containing a 'submission' as a source and of type 'referencedBy'. This node can be used with the keyword 'contains' at each relationship array of all objects (but submission), in order to assert that all objects have a submission object (EGAB...) linked to them.",
         "allOf": [
           {
-            "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+            "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
           },
           {
-            "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+            "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
           }
         ]
       },
@@ -3717,7 +3717,7 @@
         "allOf": [
           {
             "title": "ISO8601 Date pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DurationPattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DurationPattern"
           }
         ],
         "examples": [ "P3Y6M4D", "P23DT23H", "P4Y" ]
@@ -3731,7 +3731,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {        
@@ -3757,7 +3757,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {        
@@ -3796,7 +3796,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {        
@@ -3862,7 +3862,7 @@
             "allOf": [
               {
                 "title": "General CURIE pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/curieGeneralPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/curieGeneralPattern"
               }
             ],
             "examples": [ "MONDO:0100096", "EFO:0003101", "EFO:0005518",  "EFO:0002944",  "EFO:0003813" ]

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -2345,8 +2345,8 @@
             "type": "string",
             "title": "Email address",
             "description": "Current email address that would be used in case the contact needs to be reached. Its expected format is of a local-part (e.g. 'myname'), followed by an 'at' sign (i.e. '@') and the domain of the address (e.g. 'gmail.com' or 'ebi.ac.uk').",
-            "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$",
-            "examples": [ "myname@ebi.ac.uk" ]
+            "format": "idn-email",
+            "examples": [ "myname@ebi.ac.uk", "üser@example.com" ]
           },
           "phoneNumber": {
             "type": "string",

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -2078,12 +2078,7 @@
             "type": "string",
             "title": "URI of the external accession",
             "description": "Full or partial URL/URI of the external accession, for systems to resolve it. Should only be used in case identifiers.org does not contain a namespace for the required resource or the mapping to the URI from its identifier is faulty.",
-            "allOf": [
-              {
-                "title": "General pattern of a URL/URI",
-                "$ref": "./EGA.common-definitions.json#/$defs/urlUriPattern"
-              }
-            ],
+            "format": "uri",
             "examples": [ 
               "https://www.ebi.ac.uk/biosamples/samples/SAMN11716999",
               "https://pubmed.ncbi.nlm.nih.gov/19491253",
@@ -2279,12 +2274,7 @@
             "type": "string",
             "title": "URI of the schema",
             "description": "URI of the schema that describes the JSON document (e.g. 'my_sample.json')",
-            "allOf": [
-              {
-                "title": "General pattern of a URL/URI",
-                "$ref": "./EGA.common-definitions.json#/$defs/urlUriPattern"
-              }
-            ],
+            "format": "uri",
             "examples": ["https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json"]
           },
           "objectSchemaVersion": {
@@ -3683,14 +3673,6 @@
             "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
           }
         ]
-      },
-
-      "urlUriPattern": {
-        "type": "string",
-        "title": "URL/URI pattern",
-        "description": "This object exists to hold the pattern that a URL or URI should have. For it to be referenced elsewhere within this (or other) JSON schema.",
-        "pattern": "^((http|https)://)(www.)?[a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)$",
-        "examples": [ "https://phenopacket-schema.readthedocs.io/en/latest/externalreference.html", "https://www.ebi.ac.uk/arrayexpress/experiments/E-MEXP-1712/", "https://www.geeksforgeeks.org/check-if-an-url-is-valid-or-not-using-regular-expression/" ]
       },
 
       "individualAge": {

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -3698,7 +3698,7 @@
         "title": "Individual's age",
         "meta:propertyCurie": "EFO:0000246",
         "description": "Precise age in ISO8601 format of the individual. For example, 'P3Y6M4D' represents a duration of three years, six months and four days.",
-        "format": "",
+        "format": "duration",
         "examples": [ "P3Y6M4D", "P4Y", "P23DT23H", "PT0S", "P0D", "P0,5Y", "P0.5Y"]
       },
 

--- a/schemas/EGA.common-definitions.json
+++ b/schemas/EGA.common-definitions.json
@@ -748,14 +748,6 @@
         "examples": [ "EGAO00001159483" ]
       },
       
-      "EGAISO8601DatePattern": {
-        "type": "string",
-        "title": "Pattern of EGA ISO 8601 date",
-        "description": "Regular expression to check the syntax of a date following 'ISO 8601 date' format. Notice that the Time (denoted by 'T...') is optional. So is the time zone, specified at the end of the string (e.g. 'Z', '+01:00'...). See more detail at 'https://regexpattern.com/iso-8601-dates-times/'.",
-        "pattern": "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])(T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?)?$",
-        "examples": [ "2021-04-30", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
-      },
-
       "EGAISO8601DurationPattern": {
         "type": "string",
         "title": "Pattern of a partial EGA ISO 8601 duration",

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -77,12 +77,9 @@
         "type": "string",
         "title": "Approximate release date of the dataset",
         "description": "An approximate date of the desired release of the dataset. Bare in mind that this will NOT automatically release the dataset, but instead may be used to set a reminder to the submitter (and EGA's HelpDesk team) in case the dataset was not released by this time. This would help in cases where this step was forgotten by the submitter or release was stalled for some reason.",
-        "examples": [ "2023-12-01", "2024-01-10" ],
+        "format": "date",
+        "examples": [ "2023-12-01", "2024-01-10", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ],
         "allOf": [
-          {
-            "title": "The date has to match the common date pattern",
-            "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
-          },
           {
             "title": "We cap the reminder up to 3 years",
             "Description": "We cap the reminder date to 3 years so that we avoid submitters setting a reminder too far in the future, sometimes intentionally.",

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that dataset EGA ID (EGAD) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGADatasetIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGADatasetIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -81,7 +81,7 @@
         "allOf": [
           {
             "title": "The date has to match the common date pattern",
-            "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
+            "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
           },
           {
             "title": "We cap the reminder up to 3 years",
@@ -102,7 +102,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a dataset",
@@ -112,21 +112,21 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourcePolicy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourcePolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         }
                       ]
                     }
@@ -138,23 +138,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDataset"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetDataset"
                         }
                       ]
                     }
@@ -167,44 +167,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -216,7 +216,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -228,7 +228,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
       

--- a/schemas/EGA.dataset.json
+++ b/schemas/EGA.dataset.json
@@ -78,7 +78,7 @@
         "title": "Approximate release date of the dataset",
         "description": "An approximate date of the desired release of the dataset. Bare in mind that this will NOT automatically release the dataset, but instead may be used to set a reminder to the submitter (and EGA's HelpDesk team) in case the dataset was not released by this time. This would help in cases where this step was forgotten by the submitter or release was stalled for some reason.",
         "format": "date",
-        "examples": [ "2023-12-01", "2024-01-10", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ],
+        "examples": [ "2021-04-30", "2020-12-29" ],
         "allOf": [
           {
             "title": "We cap the reminder up to 3 years",

--- a/schemas/EGA.experiment.json
+++ b/schemas/EGA.experiment.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that experiment EGA ID (EGAX) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAExperimentIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAExperimentIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -57,14 +57,14 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/locusIdentifier" 
+          "$ref": "./EGA.common-definitions.json#/$defs/locusIdentifier" 
         }
       },
 
       "assayTechnology": {
         "title": "Technology used in the assay",
         "description": "Technology used in the assay. This node allows for an easy filtering of the technology (e.g. a sequencer Illumina NextSeq 500) used to obtain the raw data (e.g. sequence files) in an assay.",
-        "$ref": "./EGA.common-definitions.json#/definitions/assayTechnologyDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/assayTechnologyDescriptor"
       },
 
       "assayType": {
@@ -75,7 +75,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {
@@ -116,7 +116,7 @@
         "allOf": [
           {
             "title": "Inherited ontologyTerm structure of termId and termLabel",
-            "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+            "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
           }
         ],
         "properties": {        
@@ -141,7 +141,7 @@
         "description": "Types of data the experiment produces.",
         "uniqueItems": true,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/typeOfData"
+          "$ref": "./EGA.common-definitions.json#/$defs/typeOfData"
         }
       },
 
@@ -167,7 +167,7 @@
                 "uniqueItems": true,
                 "minItems": 1,
                 "items": {
-                  "$ref": "./EGA.common-definitions.json#/definitions/arrayLabel" 
+                  "$ref": "./EGA.common-definitions.json#/$defs/arrayLabel" 
                 }
               },
               
@@ -180,7 +180,7 @@
                 "uniqueItems": true,
                 "items": {
                   "title": "ADF File object",
-                  "$ref": "./EGA.common-definitions.json#/definitions/fileObject" 
+                  "$ref": "./EGA.common-definitions.json#/$defs/fileObject" 
                 }
               }
             }
@@ -194,12 +194,12 @@
             "properties": {
               "libraryLayout": {
                 "title": "Library layout of the sequencing experiment",
-                "$ref": "./EGA.common-definitions.json#/definitions/libraryLayout"
+                "$ref": "./EGA.common-definitions.json#/$defs/libraryLayout"
               },
               "spotDescriptor": {
                 "title": "Spot descriptor of the sequencing experiment",
                 "description": "Adapted from current ENA's XSDs without improvements. #! Expected to be investigated.",
-                "$ref": "./EGA.common-definitions.json#/definitions/spotDescriptor"
+                "$ref": "./EGA.common-definitions.json#/$defs/spotDescriptor"
               }
             }
           }
@@ -227,7 +227,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for an experiment",
@@ -237,36 +237,36 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
-                        },
-                        {
-                          "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExperiment"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExperiment"
+                        },
+                        {
+                          "title": "Optional one, added here to simplify",
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetSample"
                         }
                       ]
                     }
@@ -278,23 +278,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExperiment"
                         }
                       ]
                     }
@@ -307,44 +307,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -356,7 +356,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -368,7 +368,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     },

--- a/schemas/EGA.individual.json
+++ b/schemas/EGA.individual.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that individual EGA ID (EGAI) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAIndividualIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAIndividualIdPattern"
               }
             }
           }
@@ -32,11 +32,11 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "organismDescriptor": {
-        "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/organismDescriptor"
       },
      
       "minimalPublicAttributes":{
@@ -47,10 +47,10 @@
         "required": ["subjectId", "biologicalSex"],
         "properties": {
           "subjectId": {
-            "$ref": "./EGA.common-definitions.json#/definitions/subjectId"
+            "$ref": "./EGA.common-definitions.json#/$defs/subjectId"
           },
           "biologicalSex": {
-            "$ref": "./EGA.common-definitions.json#/definitions/biologicalSex"
+            "$ref": "./EGA.common-definitions.json#/$defs/biologicalSex"
           },
           "phenotypicAbnormalities": {
             "type": "array",
@@ -72,7 +72,7 @@
                   "default": false
                 },
                 "phenotypicAbnormality": {
-                  "$ref": "./EGA.common-definitions.json#/definitions/phenotypicAbnormality"
+                  "$ref": "./EGA.common-definitions.json#/$defs/phenotypicAbnormality"
                 }
               }
             }
@@ -97,7 +97,7 @@
                   "default": false
                 },
                 "disease": {
-                  "$ref": "./EGA.common-definitions.json#/definitions/disease"
+                  "$ref": "./EGA.common-definitions.json#/$defs/disease"
                 }
               }
             }
@@ -126,7 +126,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for an individual",
@@ -136,19 +136,19 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         }
                       ]
                     }
@@ -160,26 +160,26 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceIndividual"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceIndividual"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetIndividual"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetIndividual"
                         }
                       ]
                     }
@@ -192,44 +192,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -241,7 +241,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -253,7 +253,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }

--- a/schemas/EGA.object-set.json
+++ b/schemas/EGA.object-set.json
@@ -30,7 +30,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectArray": {

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that policy EGA ID (EGAP) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAPolicyIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAPolicyIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -94,7 +94,7 @@
           "allOf": [
             {
               "title": "Inherited ontologyTerm structure of termId and termLabel",
-              "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+              "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
             }
           ],
           "properties": {        
@@ -146,7 +146,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a policy",
@@ -156,18 +156,18 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetDataset"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetDataset"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceDAC"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceDAC"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         }
                       ]
                     }
@@ -179,20 +179,20 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourcePolicy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourcePolicy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetPolicy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetPolicy"
                         }
                       ]
                     }
@@ -205,44 +205,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -254,7 +254,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -266,7 +266,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.policy.json
+++ b/schemas/EGA.policy.json
@@ -52,7 +52,7 @@
             "type": "string",
             "title": "Reference to the policy",
             "description": "A publicly accessible reference to the policy, where the updated text of the policy is hosted.",
-            "pattern": "^(http(s)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)$",
+            "format": "uri",
             "examples": [ 
               "https://github.com/EbiEga/ega-metadata-schema/blob/main/schemas/EGA.policy.json",
               "https://ega-archive.org/submission/dac/documentation" 

--- a/schemas/EGA.protocol.json
+++ b/schemas/EGA.protocol.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that protocol EGA ID (EGAO) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAProtocolIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAProtocolIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -86,7 +86,7 @@
             "allOf": [
               {
                 "title": "Inherited ontologyTerm structure of termId and termLabel",
-                "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
               }
             ],
             "properties": {        
@@ -205,7 +205,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a protocol",
@@ -215,32 +215,32 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
-                        },
-                        {
-                          "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetStudy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetIndividual"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetStudy"
+                        },
+                        {
+                          "title": "Optional one, added here to simplify",
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetIndividual"
                         }
                       ]
                     }
@@ -252,26 +252,26 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetProtocol"
                         }
                       ]
                     }
@@ -284,38 +284,38 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -327,7 +327,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -339,7 +339,7 @@
         "uniqueItems": true,
         "minItems": 1,
         "items": {
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }      

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -65,12 +65,8 @@
             "title": "Date of the sample collection",
             "meta:propertyCurie": "EFO:0000689",
             "description": "Date when the sample was collected (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the collection concluded.",
-            "allOf": [
-              {
-                "title": "ISO8601 Date pattern",
-                "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
-              }
-            ]
+            "format": "date",
+            "examples": [ "2023-12-01", "2024-01-10", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
           },
           "ageAtCollection": {
             "type": "object",

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -66,7 +66,7 @@
             "meta:propertyCurie": "EFO:0000689",
             "description": "Date when the sample was collected (e.g. '2021-05-15'). If the protocols are too long, the date shall be the day the collection concluded.",
             "format": "date",
-            "examples": [ "2023-12-01", "2024-01-10", "2020-12-29T19:30:45.123Z", "2020-12-29", "2020-12-29T19:30:45", "2021-10-13T04:13:00+01:00", "2021-10-13T12:13:00-08:00", "2021-10-13T12:13:00" ]
+            "examples": [ "2021-04-30", "2020-12-29" ]
           },
           "ageAtCollection": {
             "type": "object",

--- a/schemas/EGA.sample.json
+++ b/schemas/EGA.sample.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that sample EGA ID (EGAN) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGASampleIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGASampleIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -50,7 +50,7 @@
       },
 
       "organismDescriptor": {
-        "$ref": "./EGA.common-definitions.json#/definitions/organismDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/organismDescriptor"
       },
       
       "sampleCollection": {
@@ -68,7 +68,7 @@
             "allOf": [
               {
                 "title": "ISO8601 Date pattern",
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAISO8601DatePattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAISO8601DatePattern"
               }
             ]
           },
@@ -80,7 +80,7 @@
             "properties": {
               "age": {
                 "title": "Individual's age at sample collection",
-                "$ref": "./EGA.common-definitions.json#/definitions/individualAge"                
+                "$ref": "./EGA.common-definitions.json#/$defs/individualAge"                
               },
               "ageRange": {
                 "type": "object",
@@ -90,11 +90,11 @@
                 "properties": {
                   "start": {
                     "title": "Start of the individual's age range",
-                    "$ref": "./EGA.common-definitions.json#/definitions/individualAge"
+                    "$ref": "./EGA.common-definitions.json#/$defs/individualAge"
                   },
                   "end": {
                     "title": "End of the individual's age range",
-                    "$ref": "./EGA.common-definitions.json#/definitions/individualAge"
+                    "$ref": "./EGA.common-definitions.json#/$defs/individualAge"
                   }
                 }
               }
@@ -117,7 +117,7 @@
             "meta:propertyCurie": "EFO:0000688",
             "allOf": [
               {
-                "$ref": "./EGA.common-definitions.json#/definitions/materialAnatomicalEntity"
+                "$ref": "./EGA.common-definitions.json#/$defs/materialAnatomicalEntity"
               }
             ]
           }
@@ -245,7 +245,7 @@
           "properties": {
             "cellType": {
               "title": "Inherited ontologyTerm for Cell types",
-              "$ref": "./EGA.common-definitions.json#/definitions/cellType"
+              "$ref": "./EGA.common-definitions.json#/$defs/cellType"
             },
             "cellTypeInferred": {
               "type": "string",
@@ -303,7 +303,7 @@
               "allOf": [
                 {
                   "title": "Inherited ontologyTerm structure of termId and termLabel",
-                  "$ref": "./EGA.common-definitions.json#/definitions/ontologyTerm"
+                  "$ref": "./EGA.common-definitions.json#/$defs/ontologyTerm"
                 }
               ],
               "properties": {        
@@ -329,7 +329,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a sample",
@@ -339,28 +339,28 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAssay"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAssay"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         },
                         { 
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceIndividual"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceIndividual"
                         }
                       ]
                     }
@@ -372,26 +372,26 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSample"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSample"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetSample"
                         }
                       ]
                     }
@@ -404,44 +404,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -453,7 +453,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -465,7 +465,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }

--- a/schemas/EGA.study.json
+++ b/schemas/EGA.study.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that study EGA ID (EGAS) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGAStudyIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGAStudyIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -91,7 +91,7 @@
         "minItems": 1,
         "items": {
           "title": "One study design",
-          "$ref": "./EGA.common-definitions.json#/definitions/studyDesignKeywords"
+          "$ref": "./EGA.common-definitions.json#/$defs/studyDesignKeywords"
         }
       },
 
@@ -106,7 +106,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a study",
@@ -116,22 +116,22 @@
                   "title": "Allowed relationships of type referencedBy (main ones)",
                   "allOf": [
                     {
-                      "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                      "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetAnalysis"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetAnalysis"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExperiment"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExperiment"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
                           "title": "Optional one, added here to simplify",
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceProtocol"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceProtocol"
                         }
                       ]
                     }
@@ -143,23 +143,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceStudy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceStudy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetStudy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetStudy"
                         }
                       ]
                     }
@@ -172,44 +172,44 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeFamilyRelationshipWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeFamilyRelationshipWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -221,7 +221,7 @@
         },
         "contains": {
           "title": "Constraint to have at least one 'submission' relationship",
-          "$ref": "./EGA.common-definitions.json#/definitions/rConstraintOneSourcedSubmission"
+          "$ref": "./EGA.common-definitions.json#/$defs/rConstraintOneSourcedSubmission"
         }
       },
 
@@ -233,7 +233,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }      
     }      

--- a/schemas/EGA.submission.json
+++ b/schemas/EGA.submission.json
@@ -16,13 +16,13 @@
         "allOf": [
           {
             "title": "Inherited objectCoreId object",
-            "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+            "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
           },
           {
             "title": "Check that Submission EGA ID (EGAB) is correct",
             "properties": {
               "egaAccession": {
-                "$ref": "./EGA.common-definitions.json#/definitions/EGASubmissionIdPattern"
+                "$ref": "./EGA.common-definitions.json#/$defs/EGASubmissionIdPattern"
               }
             }
           }
@@ -32,7 +32,7 @@
       "schemaDescriptor": {
         "title": "Schema descriptor node",
         "description": "Inherited schema descriptor node containing metadata about the schemas and standards used to create the JSON document itself.",
-        "$ref": "./EGA.common-definitions.json#/definitions/schemaDescriptor"
+        "$ref": "./EGA.common-definitions.json#/$defs/schemaDescriptor"
       },
 
       "objectTitle": {
@@ -120,7 +120,7 @@
               }
             },
             "collaboratorContactDetails": {
-              "$ref": "./EGA.common-definitions.json#/definitions/contactDetails"
+              "$ref": "./EGA.common-definitions.json#/$defs/contactDetails"
             }
           }
         }
@@ -137,7 +137,7 @@
           "allOf": [
             {
               "title": "Inherited relationship node",
-              "$ref": "./EGA.common-definitions.json#/definitions/relationshipObject"
+              "$ref": "./EGA.common-definitions.json#/$defs/relationshipObject"
             },
             {
               "title": "Relationship constraints for a submission",
@@ -149,23 +149,23 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceSubmission"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetSubmission"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetSubmission"
                         }
                       ]
                     }
@@ -178,41 +178,41 @@
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeChildOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeChildOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeGroupedWith"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeGroupedWith"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeSameAs"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeSameAs"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeReferencedBy"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeReferencedBy"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeDevelopsFrom"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeDevelopsFrom"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeMemberOf"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeMemberOf"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTypeIsAfter"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTypeIsAfter"
                         }
                       ]
                     },
                     {
                       "anyOf": [
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rSourceExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rSourceExternalURL"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalAccession"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalAccession"
                         },
                         {
-                          "$ref": "./EGA.common-definitions.json#/definitions/rTargetExternalURL"
+                          "$ref": "./EGA.common-definitions.json#/$defs/rTargetExternalURL"
                         }
                       ]
                     }
@@ -232,7 +232,7 @@
         "additionalProperties": false,
         "uniqueItems": true,
         "items": { 
-          "$ref": "./EGA.common-definitions.json#/definitions/customAttribute" 
+          "$ref": "./EGA.common-definitions.json#/$defs/customAttribute" 
         }
       }
     }      

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -23,14 +23,14 @@ In case these schemas need to be modified, in this section you will find listed 
 * **Naming conventions**. Properties within the JSON schemas follow SWIFT naming conventions: they are named in ``lowerCammelCase`` format. For example, ``md5ChecksumPattern`` versus ``md5_checksum_pattern``.
 * **Shared definitions**. All schemas share some fields (_e.g._ ``alias``) or patterns (_e.g._ checksum patterns), which can lead to duplicated code. In order to avoid it, we created an additional schema that corresponds to none of the EGA objects: ``EGA.common-definitions.json``. Within this file those repeated objects are specified for other schemas or objects to inherit. Based on the
 **source and target** (being within the same file or another) **of the reference**, we can differentiate: (1) same-file shared definitions; (2) different-file shared definitions.
-    1. **Same-file shared definitions**. Objects within a JSON schema can be reused indefinitely. In order to do so, we stored them in the **``definitions`` anchor** (at the first level of the common schema), and then referenced them elsewhere using their relative JSON pointer (its path - _e.g._ ``"#/definitions/md5ChecksumPattern"``).
+    1. **Same-file shared definitions**. Objects within a JSON schema can be reused indefinitely. In order to do so, we stored them in the **``$defs`` anchor** (at the first level of the common schema), and then referenced them elsewhere using their relative JSON pointer (its path - _e.g._ ``"#/$defs/md5ChecksumPattern"``).
     See [Definitions](https://json-schema.org/understanding-json-schema/structuring.html#definitions) section for further details.
-    As an **example**, take a look at how we defined ``md5ChecksumPattern`` within ``definitions`` of the ``EGA.common-definitions.json``:
+    As an **example**, take a look at how we defined ``md5ChecksumPattern`` within ``$defs`` of the ``EGA.common-definitions.json``:
     ````
     # Simplified common schema:
     {
         "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
-        "definitions": {
+        "$defs": {
             "md5ChecksumPattern": {
                 "type": "string",
                 "pattern": "^[0-9a-z](?:-?[0-9a-z]){31}$"
@@ -39,18 +39,18 @@ In case these schemas need to be modified, in this section you will find listed 
     }
    
     # When referencing the pattern:
-    { "$ref": "#/definitions/md5ChecksumPattern" }
+    { "$ref": "#/$defs/md5ChecksumPattern" }
     ````
 
     2. **Different-file shared definitions**. The way these cross-file references are achieved is by using the IDs of the schemas (``$id`` within its first layer) and properties' anchors (_e.g._ ``"EGASampleIdPattern``), which point to the properties within the files, turning them into references (``$ref`` wherever they are needed). References are resolved against the absolute URL identifiers of the 
     schemas. In other words, a relative reference ($ref; e.g. ``./EGA.common-definitions.json#...``) is resolved against the absolute identifier (``$id``; e.g. ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.analysis.json``) of the referencing schema (in this example ``EGA.analysis.json``), transforming the relative reference into an absolute one (e.g. 
     ``https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json#...``). See 
-    [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``objectCoreId`` within ``definitions`` of the ``EGA.common-definitions.json`` and then referenced it within the ``EGA.analysis.json``:
+    [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for further details. As an **example**, take a look at how we defined ``objectCoreId`` within ``$defs`` of the ``EGA.common-definitions.json`` and then referenced it within the ``EGA.analysis.json``:
     ````
     # Simplified common schema
     {
         "$id": "https://raw.githubusercontent.com/EbiEga/ega-metadata-schema/main/schemas/EGA.common-definitions.json",
-        "definitions": {
+        "$defs": {
             "objectCoreId": {
                 ...
             }
@@ -64,7 +64,7 @@ In case these schemas need to be modified, in this section you will find listed 
                 "type": "object",
                 "allOf": [
                     {
-                        "$ref": "./EGA.common-definitions.json#/definitions/objectCoreId"
+                        "$ref": "./EGA.common-definitions.json#/$defs/objectCoreId"
                     }
                 ]
             }


### PR DESCRIPTION
## Ticket reference
EEH-2572

## Overall changes
- Changed a few bespoke formats we had in the JSON schemas to the standard "**[format](https://json-schema.org/understanding-json-schema/reference/string.html#format)**" keyword of the built-in JSON Schema. Replaced keywords include:
   - ``EGAISO8601DatePattern`` --> ``"format": "date"``
   - ``EGAISO8601DurationPattern`` --> ``"format": "duration"``
   - ``emailAddress`` --> ``"format": "idn-email"``
   - ``urlUriPattern`` --> ``"format": "uri"`` 

## Future TO-DOs and checks
- [x] Check that the object's versions (i.e. ``meta:version``) are updated before creating the PR (see [GitHub Action](../.github/workflows/update_version_manifest.yml)). 
- [x] Check that the version manifest is up to date right before merging (see [documentation](../docs/releases/README.md#updating-the-version-manifest)). 
